### PR TITLE
Port categorized links and add calendar widget with ICS proxy

### DIFF
--- a/api/calendar-proxy.ts
+++ b/api/calendar-proxy.ts
@@ -1,0 +1,79 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+const ALLOWED_DOMAINS = [
+  "calendar.google.com",
+  "outlook.live.com",
+  "outlook.office365.com",
+  "caldav.icloud.com",
+  "calendar.yahoo.com",
+  "ics.calendarlabs.com",
+];
+
+function isAllowedUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      (parsed.protocol === "https:" || parsed.protocol === "webcal:") &&
+      ALLOWED_DOMAINS.some(
+        (domain) =>
+          parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`),
+      )
+    );
+  } catch {
+    return false;
+  }
+}
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    res.status(204).end();
+    return;
+  }
+
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const { url } = req.body ?? {};
+
+  if (!url || typeof url !== "string") {
+    res.status(400).json({ error: "Missing or invalid url parameter" });
+    return;
+  }
+
+  const fetchUrl = url.replace(/^webcal:/, "https:");
+
+  if (!isAllowedUrl(fetchUrl)) {
+    res.status(403).json({ error: "Domain not in allowlist" });
+    return;
+  }
+
+  try {
+    const response = await fetch(fetchUrl, {
+      headers: { Accept: "text/calendar" },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) {
+      res
+        .status(502)
+        .json({ error: `Upstream returned ${response.status}` });
+      return;
+    }
+
+    const text = await response.text();
+    res.setHeader("Content-Type", "text/calendar; charset=utf-8");
+    res.status(200).send(text);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(502).json({ error: `Failed to fetch calendar: ${message}` });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/preact": "^5.1.2",
         "astro": "^6.2.1",
+        "ical.js": "^2.2.1",
         "preact": "^10.29.1"
       },
       "devDependencies": {
@@ -4960,6 +4961,12 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/ical.js": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
+      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
+      "license": "MPL-2.0"
     },
     "node_modules/ignore": {
       "version": "7.0.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@astrojs/preact": "^5.1.2",
     "astro": "^6.2.1",
+    "ical.js": "^2.2.1",
     "preact": "^10.29.1"
   },
   "devDependencies": {

--- a/src/components/CalendarWidget.tsx
+++ b/src/components/CalendarWidget.tsx
@@ -1,0 +1,227 @@
+import { useState, useEffect } from "preact/hooks";
+import { calendarConfig } from "../config/calendar";
+
+interface CalendarEvent {
+  summary: string;
+  startTime: Date;
+  endTime: Date;
+  allDay: boolean;
+  color?: string;
+}
+
+const CACHE_KEY = "calendar-widget-cache";
+const CACHE_TTL_MS = calendarConfig.cacheTtlMinutes * 60 * 1000;
+
+function getCachedEvents(): CalendarEvent[] | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const { events, timestamp } = JSON.parse(raw);
+    if (Date.now() - timestamp > CACHE_TTL_MS) {
+      localStorage.removeItem(CACHE_KEY);
+      return null;
+    }
+    return events.map((e: Record<string, unknown>) => ({
+      ...e,
+      startTime: new Date(e.startTime as string),
+      endTime: new Date(e.endTime as string),
+    }));
+  } catch {
+    localStorage.removeItem(CACHE_KEY);
+    return null;
+  }
+}
+
+function setCachedEvents(events: CalendarEvent[]): void {
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ events, timestamp: Date.now() }),
+    );
+  } catch {
+    // localStorage full or unavailable
+  }
+}
+
+function parseICS(icsText: string, color?: string): CalendarEvent[] {
+  try {
+    const ICAL = (window as Record<string, unknown>).ICAL as typeof import("ical.js") | undefined;
+    if (!ICAL) return [];
+
+    const jcal = ICAL.parse(icsText);
+    const comp = new ICAL.Component(jcal);
+    const vevents = comp.getAllSubcomponents("vevent");
+
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const todayEnd = new Date(todayStart.getTime() + 86400000);
+
+    const events: CalendarEvent[] = [];
+
+    for (const vevent of vevents) {
+      const event = new ICAL.Event(vevent);
+      const start = event.startDate?.toJSDate();
+      const end = event.endDate?.toJSDate();
+
+      if (!start) continue;
+
+      const effectiveEnd = end ?? new Date(start.getTime() + 3600000);
+      const allDay = event.startDate?.isDate ?? false;
+
+      if (allDay) {
+        if (start < todayEnd && effectiveEnd > todayStart) {
+          events.push({
+            summary: event.summary ?? "Untitled",
+            startTime: start,
+            endTime: effectiveEnd,
+            allDay: true,
+            color,
+          });
+        }
+      } else {
+        if (start < todayEnd && effectiveEnd > todayStart) {
+          events.push({
+            summary: event.summary ?? "Untitled",
+            startTime: start,
+            endTime: effectiveEnd,
+            allDay: false,
+            color,
+          });
+        }
+      }
+    }
+
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+function formatTime(date: Date): string {
+  const h = date.getHours();
+  const m = date.getMinutes();
+  const ampm = h >= 12 ? "pm" : "am";
+  const hour = h % 12 || 12;
+  return m === 0 ? `${hour}${ampm}` : `${hour}:${m.toString().padStart(2, "0")}${ampm}`;
+}
+
+async function fetchCalendarEvents(): Promise<CalendarEvent[]> {
+  if (calendarConfig.sources.length === 0) return [];
+
+  const results = await Promise.allSettled(
+    calendarConfig.sources.map(async (source) => {
+      const res = await fetch("/api/calendar-proxy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: source.url }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const text = await res.text();
+      return parseICS(text, source.color);
+    }),
+  );
+
+  const events: CalendarEvent[] = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      events.push(...result.value);
+    }
+  }
+
+  events.sort((a, b) => {
+    if (a.allDay && !b.allDay) return -1;
+    if (!a.allDay && b.allDay) return 1;
+    return a.startTime.getTime() - b.startTime.getTime();
+  });
+
+  return events;
+}
+
+function LoadingSkeleton() {
+  return (
+    <div class="calendar-loading" aria-label="Loading calendar">
+      <div class="calendar-skeleton-line" />
+      <div class="calendar-skeleton-line calendar-skeleton-short" />
+      <div class="calendar-skeleton-line" />
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <p class="calendar-empty">No events today</p>
+  );
+}
+
+function ErrorState() {
+  return (
+    <p class="calendar-error-text">Could not load calendar</p>
+  );
+}
+
+export function CalendarWidget() {
+  const [events, setEvents] = useState<CalendarEvent[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const cached = getCachedEvents();
+    if (cached) {
+      setEvents(cached);
+      setLoading(false);
+      return;
+    }
+
+    if (calendarConfig.sources.length === 0) {
+      setEvents([]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    fetchCalendarEvents()
+      .then((fetched) => {
+        if (cancelled) return;
+        setEvents(fetched);
+        setCachedEvents(fetched);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError(true);
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div class="widget calendar-widget">
+      <h2 class="calendar-title">Today's Schedule</h2>
+      {loading && <LoadingSkeleton />}
+      {!loading && error && <ErrorState />}
+      {!loading && !error && events && events.length === 0 && <EmptyState />}
+      {!loading && !error && events && events.length > 0 && (
+        <ul class="calendar-event-list">
+          {events.map((event, i) => (
+            <li key={`${event.summary}-${i}`} class="calendar-event-item">
+              {event.color && (
+                <span
+                  class="calendar-event-dot"
+                  style={{ backgroundColor: event.color }}
+                />
+              )}
+              <span class="calendar-event-time">
+                {event.allDay ? "All day" : formatTime(event.startTime)}
+              </span>
+              <span class="calendar-event-summary">{event.summary}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/CalendarWidget.tsx
+++ b/src/components/CalendarWidget.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "preact/hooks";
+import ICAL from "ical.js";
 import { calendarConfig } from "../config/calendar";
 
 interface CalendarEvent {
@@ -45,9 +46,6 @@ function setCachedEvents(events: CalendarEvent[]): void {
 
 function parseICS(icsText: string, color?: string): CalendarEvent[] {
   try {
-    const ICAL = (window as Record<string, unknown>).ICAL as typeof import("ical.js") | undefined;
-    if (!ICAL) return [];
-
     const jcal = ICAL.parse(icsText);
     const comp = new ICAL.Component(jcal);
     const vevents = comp.getAllSubcomponents("vevent");
@@ -68,26 +66,14 @@ function parseICS(icsText: string, color?: string): CalendarEvent[] {
       const effectiveEnd = end ?? new Date(start.getTime() + 3600000);
       const allDay = event.startDate?.isDate ?? false;
 
-      if (allDay) {
-        if (start < todayEnd && effectiveEnd > todayStart) {
-          events.push({
-            summary: event.summary ?? "Untitled",
-            startTime: start,
-            endTime: effectiveEnd,
-            allDay: true,
-            color,
-          });
-        }
-      } else {
-        if (start < todayEnd && effectiveEnd > todayStart) {
-          events.push({
-            summary: event.summary ?? "Untitled",
-            startTime: start,
-            endTime: effectiveEnd,
-            allDay: false,
-            color,
-          });
-        }
+      if (start < todayEnd && effectiveEnd > todayStart) {
+        events.push({
+          summary: event.summary ?? "Untitled",
+          startTime: start,
+          endTime: effectiveEnd,
+          allDay,
+          color,
+        });
       }
     }
 

--- a/src/components/QuickLinksWidget.tsx
+++ b/src/components/QuickLinksWidget.tsx
@@ -1,15 +1,65 @@
+import { useState } from "preact/hooks";
+
 interface QuickLink {
   name: string;
   url: string;
   icon?: string;
 }
 
-interface Props {
+interface LinkSection {
+  title: string;
+  icon?: string;
   links: QuickLink[];
 }
 
-export function QuickLinksWidget({ links }: Props) {
-  if (!links || links.length === 0) {
+interface Props {
+  links: QuickLink[];
+  linkSections?: LinkSection[];
+}
+
+function CollapsibleSection({ section }: { section: LinkSection }) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div class="link-section">
+      <button
+        class="link-section-header"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        type="button"
+      >
+        {section.icon && <span class="link-section-icon">{section.icon}</span>}
+        <span class="link-section-title">{section.title}</span>
+        <span class={`link-section-chevron ${open ? "link-section-chevron-open" : ""}`}>
+          &#9656;
+        </span>
+      </button>
+      {open && (
+        <nav class="quick-links-grid" aria-label={`${section.title} links`}>
+          {section.links.map((link) => (
+            <a
+              key={link.url}
+              href={link.url}
+              class="quick-link-card"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={link.name}
+            >
+              {link.icon && <span class="quick-link-icon">{link.icon}</span>}
+              <span class="quick-link-name">{link.name}</span>
+            </a>
+          ))}
+        </nav>
+      )}
+    </div>
+  );
+}
+
+export function QuickLinksWidget({ links, linkSections }: Props) {
+  const hasLinks = links && links.length > 0;
+  const hasSections = linkSections && linkSections.length > 0;
+
+  if (!hasLinks && !hasSections) {
     return (
       <div class="widget quick-links-widget">
         <p class="quick-links-empty">No links configured</p>
@@ -20,21 +70,27 @@ export function QuickLinksWidget({ links }: Props) {
   return (
     <div class="widget quick-links-widget">
       <h2 class="quick-links-title">Quick Links</h2>
-      <nav class="quick-links-grid" aria-label="Quick links">
-        {links.map((link) => (
-          <a
-            key={link.url}
-            href={link.url}
-            class="quick-link-card"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={link.name}
-          >
-            {link.icon && <span class="quick-link-icon">{link.icon}</span>}
-            <span class="quick-link-name">{link.name}</span>
-          </a>
+      {hasLinks && (
+        <nav class="quick-links-grid" aria-label="Quick links">
+          {links.map((link) => (
+            <a
+              key={link.url}
+              href={link.url}
+              class="quick-link-card"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={link.name}
+            >
+              {link.icon && <span class="quick-link-icon">{link.icon}</span>}
+              <span class="quick-link-name">{link.name}</span>
+            </a>
+          ))}
+        </nav>
+      )}
+      {hasSections &&
+        linkSections.map((section) => (
+          <CollapsibleSection key={section.title} section={section} />
         ))}
-      </nav>
     </div>
   );
 }

--- a/src/components/QuickLinksWidget.tsx
+++ b/src/components/QuickLinksWidget.tsx
@@ -1,16 +1,5 @@
 import { useState } from "preact/hooks";
-
-interface QuickLink {
-  name: string;
-  url: string;
-  icon?: string;
-}
-
-interface LinkSection {
-  title: string;
-  icon?: string;
-  links: QuickLink[];
-}
+import type { QuickLink, LinkSection } from "../config/types";
 
 interface Props {
   links: QuickLink[];

--- a/src/config/calendar.ts
+++ b/src/config/calendar.ts
@@ -1,0 +1,6 @@
+import type { CalendarConfig } from "./types";
+
+export const calendarConfig: CalendarConfig = {
+  sources: [],
+  cacheTtlMinutes: 15,
+};

--- a/src/config/days/friday.ts
+++ b/src/config/days/friday.ts
@@ -1,4 +1,5 @@
 import type { DayConfig } from "../types";
+import { socialsSection, professionalSection } from "../shared-links";
 
 const friday: DayConfig = {
   name: "friday",
@@ -28,27 +29,7 @@ const friday: DayConfig = {
     { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
     { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
   ],
-  linkSections: [
-    {
-      title: "Socials",
-      icon: "👤",
-      links: [
-        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
-        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
-        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
-        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
-      ],
-    },
-    {
-      title: "Email & Professional",
-      icon: "📧",
-      links: [
-        { name: "Gmail", url: "https://mail.google.com" },
-        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
-        { name: "LinkedIn", url: "https://www.linkedin.com" },
-      ],
-    },
-  ],
+  linkSections: [socialsSection, professionalSection],
   focusText: "Wind-down day. Close open loops and plan for next week.",
 };
 

--- a/src/config/days/friday.ts
+++ b/src/config/days/friday.ts
@@ -23,10 +23,31 @@ const friday: DayConfig = {
     { id: "notes" },
   ],
   quickLinks: [
-    { name: "Email", url: "https://mail.google.com", icon: "📧" },
+    { name: "Gmail", url: "https://mail.google.com", icon: "📧" },
     { name: "Calendar", url: "https://calendar.google.com", icon: "📅" },
-    { name: "Music", url: "https://open.spotify.com", icon: "🎵" },
-    { name: "News", url: "https://news.ycombinator.com", icon: "📰" },
+    { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
+    { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+  ],
+  linkSections: [
+    {
+      title: "Socials",
+      icon: "👤",
+      links: [
+        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
+        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
+        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
+      ],
+    },
+    {
+      title: "Email & Professional",
+      icon: "📧",
+      links: [
+        { name: "Gmail", url: "https://mail.google.com" },
+        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
+        { name: "LinkedIn", url: "https://www.linkedin.com" },
+      ],
+    },
   ],
   focusText: "Wind-down day. Close open loops and plan for next week.",
 };

--- a/src/config/days/monday.ts
+++ b/src/config/days/monday.ts
@@ -1,4 +1,5 @@
 import type { DayConfig } from "../types";
+import { socialsSection, professionalSection } from "../shared-links";
 
 const monday: DayConfig = {
   name: "monday",
@@ -28,27 +29,7 @@ const monday: DayConfig = {
     { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
     { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
   ],
-  linkSections: [
-    {
-      title: "Socials",
-      icon: "👤",
-      links: [
-        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
-        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
-        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
-        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
-      ],
-    },
-    {
-      title: "Email & Professional",
-      icon: "📧",
-      links: [
-        { name: "Gmail", url: "https://mail.google.com" },
-        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
-        { name: "LinkedIn", url: "https://www.linkedin.com" },
-      ],
-    },
-  ],
+  linkSections: [socialsSection, professionalSection],
   focusText: "Deep work day. Tackle your hardest task first.",
 };
 

--- a/src/config/days/monday.ts
+++ b/src/config/days/monday.ts
@@ -23,10 +23,31 @@ const monday: DayConfig = {
     { id: "notes" },
   ],
   quickLinks: [
-    { name: "Email", url: "https://mail.google.com", icon: "📧" },
+    { name: "Gmail", url: "https://mail.google.com", icon: "📧" },
     { name: "Calendar", url: "https://calendar.google.com", icon: "📅" },
-    { name: "Tasks", url: "https://todoist.com", icon: "✅" },
-    { name: "Docs", url: "https://docs.google.com", icon: "📝" },
+    { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
+    { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+  ],
+  linkSections: [
+    {
+      title: "Socials",
+      icon: "👤",
+      links: [
+        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
+        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
+        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
+      ],
+    },
+    {
+      title: "Email & Professional",
+      icon: "📧",
+      links: [
+        { name: "Gmail", url: "https://mail.google.com" },
+        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
+        { name: "LinkedIn", url: "https://www.linkedin.com" },
+      ],
+    },
   ],
   focusText: "Deep work day. Tackle your hardest task first.",
 };

--- a/src/config/days/saturday.ts
+++ b/src/config/days/saturday.ts
@@ -23,10 +23,53 @@ const saturday: DayConfig = {
     { id: "notes" },
   ],
   quickLinks: [
-    { name: "YouTube", url: "https://youtube.com", icon: "📺" },
-    { name: "Reddit", url: "https://reddit.com", icon: "💭" },
-    { name: "Music", url: "https://open.spotify.com", icon: "🎵" },
-    { name: "Recipes", url: "https://www.allrecipes.com", icon: "🍳" },
+    { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+    { name: "ESPN Fantasy", url: "https://fantasy.espn.com/baseball/league?leagueId=4739&seasonId=2025", icon: "⚾" },
+    { name: "Action Network", url: "https://www.actionnetwork.com", icon: "📊" },
+    { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+  ],
+  linkSections: [
+    {
+      title: "Socials",
+      icon: "👤",
+      links: [
+        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
+        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
+        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
+      ],
+    },
+    {
+      title: "Sports Blogs & News",
+      icon: "📰",
+      links: [
+        { name: "Auburn Sports", url: "https://www.on3.com/teams/auburn-tigers/", icon: "🐯" },
+        { name: "Auburn Message Board", url: "https://www.on3.com/boards/forums/the-corner.22/", icon: "💬" },
+        { name: "Chelsea FC", url: "https://www.chelseafc.com/en", icon: "⚽" },
+      ],
+    },
+    {
+      title: "Sports Betting",
+      icon: "📊",
+      links: [
+        { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+        { name: "Action Network", url: "https://www.actionnetwork.com", icon: "📊" },
+        { name: "KenPom", url: "https://kenpom.com", icon: "📈" },
+        { name: "Establish The Run", url: "https://establishtherun.com", icon: "🏈" },
+        { name: "Fantasy Labs", url: "https://www.fantasylabs.com", icon: "🔬" },
+      ],
+    },
+    {
+      title: "Fantasy Sports",
+      icon: "🏆",
+      links: [
+        { name: "ESPN Fantasy Baseball", url: "https://fantasy.espn.com/baseball/league?leagueId=4739&seasonId=2025", icon: "⚾" },
+        { name: "Yahoo FF League 1", url: "https://football.fantasysports.yahoo.com/f1/655705/1", icon: "🏈" },
+        { name: "Yahoo FF League 2", url: "https://football.fantasysports.yahoo.com/f1/252107", icon: "🏈" },
+        { name: "Yahoo FF League 3", url: "https://football.fantasysports.yahoo.com", icon: "🏈" },
+        { name: "Sleeper Fantasy", url: "https://sleeper.com", icon: "🌙" },
+      ],
+    },
   ],
   focusText: "Your day off. Explore, rest, or pursue a passion project.",
 };

--- a/src/config/days/saturday.ts
+++ b/src/config/days/saturday.ts
@@ -1,4 +1,10 @@
 import type { DayConfig } from "../types";
+import {
+  socialsSection,
+  sportsNewsSection,
+  sportsBettingSection,
+  fantasySportsSection,
+} from "../shared-links";
 
 const saturday: DayConfig = {
   name: "saturday",
@@ -29,47 +35,10 @@ const saturday: DayConfig = {
     { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
   ],
   linkSections: [
-    {
-      title: "Socials",
-      icon: "👤",
-      links: [
-        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
-        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
-        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
-        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
-      ],
-    },
-    {
-      title: "Sports Blogs & News",
-      icon: "📰",
-      links: [
-        { name: "Auburn Sports", url: "https://www.on3.com/teams/auburn-tigers/", icon: "🐯" },
-        { name: "Auburn Message Board", url: "https://www.on3.com/boards/forums/the-corner.22/", icon: "💬" },
-        { name: "Chelsea FC", url: "https://www.chelseafc.com/en", icon: "⚽" },
-      ],
-    },
-    {
-      title: "Sports Betting",
-      icon: "📊",
-      links: [
-        { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
-        { name: "Action Network", url: "https://www.actionnetwork.com", icon: "📊" },
-        { name: "KenPom", url: "https://kenpom.com", icon: "📈" },
-        { name: "Establish The Run", url: "https://establishtherun.com", icon: "🏈" },
-        { name: "Fantasy Labs", url: "https://www.fantasylabs.com", icon: "🔬" },
-      ],
-    },
-    {
-      title: "Fantasy Sports",
-      icon: "🏆",
-      links: [
-        { name: "ESPN Fantasy Baseball", url: "https://fantasy.espn.com/baseball/league?leagueId=4739&seasonId=2025", icon: "⚾" },
-        { name: "Yahoo FF League 1", url: "https://football.fantasysports.yahoo.com/f1/655705/1", icon: "🏈" },
-        { name: "Yahoo FF League 2", url: "https://football.fantasysports.yahoo.com/f1/252107", icon: "🏈" },
-        { name: "Yahoo FF League 3", url: "https://football.fantasysports.yahoo.com", icon: "🏈" },
-        { name: "Sleeper Fantasy", url: "https://sleeper.com", icon: "🌙" },
-      ],
-    },
+    socialsSection,
+    sportsNewsSection,
+    sportsBettingSection,
+    fantasySportsSection,
   ],
   focusText: "Your day off. Explore, rest, or pursue a passion project.",
 };

--- a/src/config/days/sunday.ts
+++ b/src/config/days/sunday.ts
@@ -1,4 +1,11 @@
 import type { DayConfig } from "../types";
+import {
+  socialsSection,
+  professionalSection,
+  sportsNewsSection,
+  sportsBettingSection,
+  fantasySportsSection,
+} from "../shared-links";
 
 const sunday: DayConfig = {
   name: "sunday",
@@ -29,56 +36,11 @@ const sunday: DayConfig = {
     { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
   ],
   linkSections: [
-    {
-      title: "Socials",
-      icon: "👤",
-      links: [
-        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
-        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
-        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
-        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
-      ],
-    },
-    {
-      title: "Email & Professional",
-      icon: "📧",
-      links: [
-        { name: "Gmail", url: "https://mail.google.com" },
-        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
-        { name: "LinkedIn", url: "https://www.linkedin.com" },
-      ],
-    },
-    {
-      title: "Sports Blogs & News",
-      icon: "📰",
-      links: [
-        { name: "Auburn Sports", url: "https://www.on3.com/teams/auburn-tigers/", icon: "🐯" },
-        { name: "Auburn Message Board", url: "https://www.on3.com/boards/forums/the-corner.22/", icon: "💬" },
-        { name: "Chelsea FC", url: "https://www.chelseafc.com/en", icon: "⚽" },
-      ],
-    },
-    {
-      title: "Sports Betting",
-      icon: "📊",
-      links: [
-        { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
-        { name: "Action Network", url: "https://www.actionnetwork.com", icon: "📊" },
-        { name: "KenPom", url: "https://kenpom.com", icon: "📈" },
-        { name: "Establish The Run", url: "https://establishtherun.com", icon: "🏈" },
-        { name: "Fantasy Labs", url: "https://www.fantasylabs.com", icon: "🔬" },
-      ],
-    },
-    {
-      title: "Fantasy Sports",
-      icon: "🏆",
-      links: [
-        { name: "ESPN Fantasy Baseball", url: "https://fantasy.espn.com/baseball/league?leagueId=4739&seasonId=2025", icon: "⚾" },
-        { name: "Yahoo FF League 1", url: "https://football.fantasysports.yahoo.com/f1/655705/1", icon: "🏈" },
-        { name: "Yahoo FF League 2", url: "https://football.fantasysports.yahoo.com/f1/252107", icon: "🏈" },
-        { name: "Yahoo FF League 3", url: "https://football.fantasysports.yahoo.com", icon: "🏈" },
-        { name: "Sleeper Fantasy", url: "https://sleeper.com", icon: "🌙" },
-      ],
-    },
+    socialsSection,
+    professionalSection,
+    sportsNewsSection,
+    sportsBettingSection,
+    fantasySportsSection,
   ],
   focusText: "Calm day. Reflect on the past week and prepare for the next.",
 };

--- a/src/config/days/sunday.ts
+++ b/src/config/days/sunday.ts
@@ -23,10 +23,62 @@ const sunday: DayConfig = {
     { id: "notes" },
   ],
   quickLinks: [
-    { name: "Reading", url: "https://medium.com", icon: "📚" },
-    { name: "News", url: "https://news.ycombinator.com", icon: "📰" },
-    { name: "Music", url: "https://open.spotify.com", icon: "🎵" },
-    { name: "Journal", url: "https://notion.so", icon: "✍️" },
+    { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+    { name: "ESPN Fantasy", url: "https://fantasy.espn.com/baseball/league?leagueId=4739&seasonId=2025", icon: "⚾" },
+    { name: "Action Network", url: "https://www.actionnetwork.com", icon: "📊" },
+    { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+  ],
+  linkSections: [
+    {
+      title: "Socials",
+      icon: "👤",
+      links: [
+        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
+        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
+        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
+      ],
+    },
+    {
+      title: "Email & Professional",
+      icon: "📧",
+      links: [
+        { name: "Gmail", url: "https://mail.google.com" },
+        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
+        { name: "LinkedIn", url: "https://www.linkedin.com" },
+      ],
+    },
+    {
+      title: "Sports Blogs & News",
+      icon: "📰",
+      links: [
+        { name: "Auburn Sports", url: "https://www.on3.com/teams/auburn-tigers/", icon: "🐯" },
+        { name: "Auburn Message Board", url: "https://www.on3.com/boards/forums/the-corner.22/", icon: "💬" },
+        { name: "Chelsea FC", url: "https://www.chelseafc.com/en", icon: "⚽" },
+      ],
+    },
+    {
+      title: "Sports Betting",
+      icon: "📊",
+      links: [
+        { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+        { name: "Action Network", url: "https://www.actionnetwork.com", icon: "📊" },
+        { name: "KenPom", url: "https://kenpom.com", icon: "📈" },
+        { name: "Establish The Run", url: "https://establishtherun.com", icon: "🏈" },
+        { name: "Fantasy Labs", url: "https://www.fantasylabs.com", icon: "🔬" },
+      ],
+    },
+    {
+      title: "Fantasy Sports",
+      icon: "🏆",
+      links: [
+        { name: "ESPN Fantasy Baseball", url: "https://fantasy.espn.com/baseball/league?leagueId=4739&seasonId=2025", icon: "⚾" },
+        { name: "Yahoo FF League 1", url: "https://football.fantasysports.yahoo.com/f1/655705/1", icon: "🏈" },
+        { name: "Yahoo FF League 2", url: "https://football.fantasysports.yahoo.com/f1/252107", icon: "🏈" },
+        { name: "Yahoo FF League 3", url: "https://football.fantasysports.yahoo.com", icon: "🏈" },
+        { name: "Sleeper Fantasy", url: "https://sleeper.com", icon: "🌙" },
+      ],
+    },
   ],
   focusText: "Calm day. Reflect on the past week and prepare for the next.",
 };

--- a/src/config/days/thursday.ts
+++ b/src/config/days/thursday.ts
@@ -23,10 +23,31 @@ const thursday: DayConfig = {
     { id: "notes" },
   ],
   quickLinks: [
-    { name: "GitHub", url: "https://github.com", icon: "💻" },
-    { name: "Stack Overflow", url: "https://stackoverflow.com", icon: "🔍" },
-    { name: "Figma", url: "https://figma.com", icon: "🎨" },
-    { name: "Slack", url: "https://slack.com", icon: "💬" },
+    { name: "Gmail", url: "https://mail.google.com", icon: "📧" },
+    { name: "Calendar", url: "https://calendar.google.com", icon: "📅" },
+    { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
+    { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+  ],
+  linkSections: [
+    {
+      title: "Socials",
+      icon: "👤",
+      links: [
+        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
+        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
+        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
+      ],
+    },
+    {
+      title: "Email & Professional",
+      icon: "📧",
+      links: [
+        { name: "Gmail", url: "https://mail.google.com" },
+        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
+        { name: "LinkedIn", url: "https://www.linkedin.com" },
+      ],
+    },
   ],
   focusText: "Energy day. Channel your momentum into creative solutions.",
 };

--- a/src/config/days/thursday.ts
+++ b/src/config/days/thursday.ts
@@ -1,4 +1,5 @@
 import type { DayConfig } from "../types";
+import { socialsSection, professionalSection } from "../shared-links";
 
 const thursday: DayConfig = {
   name: "thursday",
@@ -28,27 +29,7 @@ const thursday: DayConfig = {
     { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
     { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
   ],
-  linkSections: [
-    {
-      title: "Socials",
-      icon: "👤",
-      links: [
-        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
-        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
-        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
-        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
-      ],
-    },
-    {
-      title: "Email & Professional",
-      icon: "📧",
-      links: [
-        { name: "Gmail", url: "https://mail.google.com" },
-        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
-        { name: "LinkedIn", url: "https://www.linkedin.com" },
-      ],
-    },
-  ],
+  linkSections: [socialsSection, professionalSection],
   focusText: "Energy day. Channel your momentum into creative solutions.",
 };
 

--- a/src/config/days/tuesday.ts
+++ b/src/config/days/tuesday.ts
@@ -23,10 +23,31 @@ const tuesday: DayConfig = {
     { id: "notes" },
   ],
   quickLinks: [
-    { name: "GitHub", url: "https://github.com", icon: "💻" },
-    { name: "Slack", url: "https://slack.com", icon: "💬" },
-    { name: "Jira", url: "https://jira.atlassian.com", icon: "📋" },
-    { name: "Docs", url: "https://docs.google.com", icon: "📝" },
+    { name: "Gmail", url: "https://mail.google.com", icon: "📧" },
+    { name: "Calendar", url: "https://calendar.google.com", icon: "📅" },
+    { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
+    { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+  ],
+  linkSections: [
+    {
+      title: "Socials",
+      icon: "👤",
+      links: [
+        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
+        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
+        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
+      ],
+    },
+    {
+      title: "Email & Professional",
+      icon: "📧",
+      links: [
+        { name: "Gmail", url: "https://mail.google.com" },
+        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
+        { name: "LinkedIn", url: "https://www.linkedin.com" },
+      ],
+    },
   ],
   focusText: "Collaboration day. Sync with your team and move projects forward.",
 };

--- a/src/config/days/tuesday.ts
+++ b/src/config/days/tuesday.ts
@@ -1,4 +1,5 @@
 import type { DayConfig } from "../types";
+import { socialsSection, professionalSection } from "../shared-links";
 
 const tuesday: DayConfig = {
   name: "tuesday",
@@ -28,27 +29,7 @@ const tuesday: DayConfig = {
     { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
     { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
   ],
-  linkSections: [
-    {
-      title: "Socials",
-      icon: "👤",
-      links: [
-        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
-        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
-        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
-        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
-      ],
-    },
-    {
-      title: "Email & Professional",
-      icon: "📧",
-      links: [
-        { name: "Gmail", url: "https://mail.google.com" },
-        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
-        { name: "LinkedIn", url: "https://www.linkedin.com" },
-      ],
-    },
-  ],
+  linkSections: [socialsSection, professionalSection],
   focusText: "Collaboration day. Sync with your team and move projects forward.",
 };
 

--- a/src/config/days/wednesday.ts
+++ b/src/config/days/wednesday.ts
@@ -1,4 +1,5 @@
 import type { DayConfig } from "../types";
+import { socialsSection, professionalSection } from "../shared-links";
 
 const wednesday: DayConfig = {
   name: "wednesday",
@@ -28,27 +29,7 @@ const wednesday: DayConfig = {
     { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
     { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
   ],
-  linkSections: [
-    {
-      title: "Socials",
-      icon: "👤",
-      links: [
-        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
-        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
-        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
-        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
-      ],
-    },
-    {
-      title: "Email & Professional",
-      icon: "📧",
-      links: [
-        { name: "Gmail", url: "https://mail.google.com" },
-        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
-        { name: "LinkedIn", url: "https://www.linkedin.com" },
-      ],
-    },
-  ],
+  linkSections: [socialsSection, professionalSection],
   focusText: "Balance day. Review progress and adjust course.",
 };
 

--- a/src/config/days/wednesday.ts
+++ b/src/config/days/wednesday.ts
@@ -23,10 +23,31 @@ const wednesday: DayConfig = {
     { id: "notes" },
   ],
   quickLinks: [
-    { name: "Email", url: "https://mail.google.com", icon: "📧" },
+    { name: "Gmail", url: "https://mail.google.com", icon: "📧" },
     { name: "Calendar", url: "https://calendar.google.com", icon: "📅" },
-    { name: "Notes", url: "https://notion.so", icon: "📓" },
-    { name: "Drive", url: "https://drive.google.com", icon: "📁" },
+    { name: "LinkedIn", url: "https://www.linkedin.com", icon: "💼" },
+    { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+  ],
+  linkSections: [
+    {
+      title: "Socials",
+      icon: "👤",
+      links: [
+        { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
+        { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
+        { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+        { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
+      ],
+    },
+    {
+      title: "Email & Professional",
+      icon: "📧",
+      links: [
+        { name: "Gmail", url: "https://mail.google.com" },
+        { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
+        { name: "LinkedIn", url: "https://www.linkedin.com" },
+      ],
+    },
   ],
   focusText: "Balance day. Review progress and adjust course.",
 };

--- a/src/config/shared-links.ts
+++ b/src/config/shared-links.ts
@@ -1,0 +1,56 @@
+import type { LinkSection } from "./types";
+
+export const socialsSection: LinkSection = {
+  title: "Socials",
+  icon: "👤",
+  links: [
+    { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
+    { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
+    { name: "Reddit", url: "https://www.reddit.com/", icon: "🤖" },
+    { name: "YouTube", url: "https://www.youtube.com/", icon: "📺" },
+  ],
+};
+
+export const professionalSection: LinkSection = {
+  title: "Email & Professional",
+  icon: "📧",
+  links: [
+    { name: "Gmail", url: "https://mail.google.com" },
+    { name: "Yahoo Mail", url: "https://mail.yahoo.com" },
+    { name: "LinkedIn", url: "https://www.linkedin.com" },
+  ],
+};
+
+export const sportsNewsSection: LinkSection = {
+  title: "Sports Blogs & News",
+  icon: "📰",
+  links: [
+    { name: "Auburn Sports", url: "https://www.on3.com/teams/auburn-tigers/", icon: "🐯" },
+    { name: "Auburn Message Board", url: "https://www.on3.com/boards/forums/the-corner.22/", icon: "💬" },
+    { name: "Chelsea FC", url: "https://www.chelseafc.com/en", icon: "⚽" },
+  ],
+};
+
+export const sportsBettingSection: LinkSection = {
+  title: "Sports Betting",
+  icon: "📊",
+  links: [
+    { name: "DraftKings", url: "https://sportsbook.draftkings.com", icon: "🎲" },
+    { name: "Action Network", url: "https://www.actionnetwork.com", icon: "📊" },
+    { name: "KenPom", url: "https://kenpom.com", icon: "📈" },
+    { name: "Establish The Run", url: "https://establishtherun.com", icon: "🏈" },
+    { name: "Fantasy Labs", url: "https://www.fantasylabs.com", icon: "🔬" },
+  ],
+};
+
+export const fantasySportsSection: LinkSection = {
+  title: "Fantasy Sports",
+  icon: "🏆",
+  links: [
+    { name: "ESPN Fantasy Baseball", url: "https://fantasy.espn.com/baseball/league?leagueId=4739&seasonId=2025", icon: "⚾" },
+    { name: "Yahoo FF League 1", url: "https://football.fantasysports.yahoo.com/f1/655705/1", icon: "🏈" },
+    { name: "Yahoo FF League 2", url: "https://football.fantasysports.yahoo.com/f1/252107", icon: "🏈" },
+    { name: "Yahoo FF League 3", url: "https://football.fantasysports.yahoo.com", icon: "🏈" },
+    { name: "Sleeper Fantasy", url: "https://sleeper.com", icon: "🌙" },
+  ],
+};

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -20,6 +20,12 @@ export interface QuickLink {
   icon?: string;
 }
 
+export interface LinkSection {
+  title: string;
+  icon?: string;
+  links: QuickLink[];
+}
+
 export interface WidgetSlot {
   id: string;
   props?: Record<string, unknown>;
@@ -31,7 +37,19 @@ export interface DayConfig {
   greeting: Greeting;
   widgets: WidgetSlot[];
   quickLinks: QuickLink[];
+  linkSections?: LinkSection[];
   focusText: string;
+}
+
+export interface CalendarSource {
+  name: string;
+  url: string;
+  color?: string;
+}
+
+export interface CalendarConfig {
+  sources: CalendarSource[];
+  cacheTtlMinutes: number;
 }
 
 export type DayName =

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -271,6 +271,137 @@ const { title = "Personal Dashboard" } = Astro.props;
         font-size: 0.875rem;
         text-align: center;
       }
+
+      .link-section {
+        margin-top: 0.75rem;
+      }
+
+      .link-section-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        width: 100%;
+        padding: 0.5rem 0;
+        background: none;
+        border: none;
+        cursor: pointer;
+        font-size: 0.8125rem;
+        font-weight: 600;
+        color: var(--color-secondary);
+        text-align: left;
+        font-family: inherit;
+      }
+
+      .link-section-header:hover {
+        color: var(--color-primary);
+      }
+
+      .link-section-header:focus-visible {
+        outline: 2px solid var(--color-primary);
+        outline-offset: 2px;
+        border-radius: 4px;
+      }
+
+      .link-section-icon {
+        font-size: 0.875rem;
+        flex-shrink: 0;
+      }
+
+      .link-section-title {
+        flex-grow: 1;
+      }
+
+      .link-section-chevron {
+        font-size: 0.75rem;
+        transition: transform 0.2s ease;
+        flex-shrink: 0;
+      }
+
+      .link-section-chevron-open {
+        transform: rotate(90deg);
+      }
+
+      .calendar-widget {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .calendar-title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-primary);
+        margin-bottom: 0.75rem;
+      }
+
+      .calendar-loading {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .calendar-skeleton-line {
+        height: 1rem;
+        border-radius: 4px;
+        background: linear-gradient(90deg, var(--color-background) 25%, var(--color-surface) 50%, var(--color-background) 75%);
+        background-size: 200% 100%;
+        animation: shimmer 1.5s infinite;
+      }
+
+      .calendar-skeleton-short {
+        width: 60%;
+      }
+
+      @keyframes shimmer {
+        0% { background-position: 200% 0; }
+        100% { background-position: -200% 0; }
+      }
+
+      .calendar-empty,
+      .calendar-error-text {
+        color: var(--color-secondary);
+        font-size: 0.875rem;
+        text-align: center;
+        padding: 1rem 0;
+      }
+
+      .calendar-event-list {
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+      }
+
+      .calendar-event-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.375rem 0.5rem;
+        border-radius: 6px;
+        font-size: 0.8125rem;
+        background-color: var(--color-background);
+      }
+
+      .calendar-event-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+
+      .calendar-event-time {
+        color: var(--color-secondary);
+        font-size: 0.75rem;
+        white-space: nowrap;
+        min-width: 3.5rem;
+        flex-shrink: 0;
+      }
+
+      .calendar-event-summary {
+        color: var(--color-text);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     </style>
   </head>
   <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import { QuickLinksWidget } from "../components/QuickLinksWidget";
 import { WeatherWidget } from "../components/WeatherWidget";
 import { QuoteWidget } from "../components/QuoteWidget";
 import { NotesWidget } from "../components/NotesWidget";
+import { CalendarWidget } from "../components/CalendarWidget";
 
 const config = getDayConfig();
 const greeting = getGreeting();
@@ -30,7 +31,11 @@ const timeOfDay = getTimeOfDay();
       </WidgetWrapper>
 
       <WidgetWrapper name="quickLinks" client:load>
-        <QuickLinksWidget links={config.quickLinks} />
+        <QuickLinksWidget links={config.quickLinks} linkSections={config.linkSections} />
+      </WidgetWrapper>
+
+      <WidgetWrapper name="calendar" client:load>
+        <CalendarWidget />
       </WidgetWrapper>
 
       <WidgetWrapper name="quote" client:idle>

--- a/tests/calendar-widget.test.tsx
+++ b/tests/calendar-widget.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/preact";
+import { CalendarWidget } from "../src/components/CalendarWidget";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("CalendarWidget", () => {
+  it("renders title", () => {
+    render(<CalendarWidget />);
+    expect(screen.getByText("Today's Schedule")).toBeTruthy();
+  });
+
+  it("shows empty state when no calendar sources configured", async () => {
+    render(<CalendarWidget />);
+    const empty = await screen.findByText("No events today");
+    expect(empty).toBeTruthy();
+  });
+
+  it("renders without crashing in widget wrapper", () => {
+    expect(() => render(<CalendarWidget />)).not.toThrow();
+  });
+});
+
+describe("CalendarWidget localStorage caching", () => {
+  it("reads from cache when available and not expired", async () => {
+    const cached = {
+      events: [],
+      timestamp: Date.now(),
+    };
+    localStorage.setItem("calendar-widget-cache", JSON.stringify(cached));
+
+    render(<CalendarWidget />);
+    const empty = await screen.findByText("No events today");
+    expect(empty).toBeTruthy();
+  });
+
+  it("ignores expired cache", async () => {
+    const cached = {
+      events: [
+        {
+          summary: "Old Event",
+          startTime: new Date().toISOString(),
+          endTime: new Date().toISOString(),
+          allDay: false,
+        },
+      ],
+      timestamp: Date.now() - 20 * 60 * 1000,
+    };
+    localStorage.setItem("calendar-widget-cache", JSON.stringify(cached));
+
+    render(<CalendarWidget />);
+    const empty = await screen.findByText("No events today");
+    expect(empty).toBeTruthy();
+  });
+
+  it("handles corrupted cache gracefully", async () => {
+    localStorage.setItem("calendar-widget-cache", "not valid json{{{");
+
+    render(<CalendarWidget />);
+    const empty = await screen.findByText("No events today");
+    expect(empty).toBeTruthy();
+  });
+});

--- a/tests/quick-links-sections.test.tsx
+++ b/tests/quick-links-sections.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/preact";
+import { QuickLinksWidget } from "../src/components/QuickLinksWidget";
+
+afterEach(cleanup);
+
+const sampleLinks = [
+  { name: "Gmail", url: "https://mail.google.com", icon: "📧" },
+  { name: "Calendar", url: "https://calendar.google.com", icon: "📅" },
+];
+
+const sampleSections = [
+  {
+    title: "Socials",
+    icon: "👤",
+    links: [
+      { name: "Twitter/X", url: "https://x.com/home", icon: "𝕏" },
+      { name: "Instagram", url: "https://www.instagram.com/", icon: "📷" },
+    ],
+  },
+  {
+    title: "Professional",
+    icon: "📧",
+    links: [
+      { name: "LinkedIn", url: "https://www.linkedin.com" },
+    ],
+  },
+];
+
+describe("QuickLinksWidget with sections", () => {
+  it("renders quick links and section headers", () => {
+    render(<QuickLinksWidget links={sampleLinks} linkSections={sampleSections} />);
+    expect(screen.getByText("Quick Links")).toBeTruthy();
+    expect(screen.getByText("Gmail")).toBeTruthy();
+    expect(screen.getByText("Calendar")).toBeTruthy();
+    expect(screen.getByText("Socials")).toBeTruthy();
+    expect(screen.getByText("Professional")).toBeTruthy();
+    expect(screen.getByText("Twitter/X")).toBeTruthy();
+    expect(screen.getByText("LinkedIn")).toBeTruthy();
+  });
+
+  it("renders without sections when linkSections is undefined", () => {
+    render(<QuickLinksWidget links={sampleLinks} />);
+    expect(screen.getByText("Quick Links")).toBeTruthy();
+    expect(screen.getByText("Gmail")).toBeTruthy();
+    expect(screen.queryByText("Socials")).toBeNull();
+  });
+
+  it("renders empty state when no links and no sections", () => {
+    render(<QuickLinksWidget links={[]} linkSections={[]} />);
+    expect(screen.getByText("No links configured")).toBeTruthy();
+  });
+
+  it("collapses and expands sections on click", () => {
+    render(<QuickLinksWidget links={sampleLinks} linkSections={sampleSections} />);
+
+    const socialsButton = screen.getByText("Socials").closest("button")!;
+    expect(screen.getByText("Twitter/X")).toBeTruthy();
+
+    fireEvent.click(socialsButton);
+    expect(screen.queryByText("Twitter/X")).toBeNull();
+
+    fireEvent.click(socialsButton);
+    expect(screen.getByText("Twitter/X")).toBeTruthy();
+  });
+
+  it("section headers have aria-expanded attribute", () => {
+    render(<QuickLinksWidget links={sampleLinks} linkSections={sampleSections} />);
+    const socialsButton = screen.getByText("Socials").closest("button")!;
+    expect(socialsButton.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(socialsButton);
+    expect(socialsButton.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("renders sections with only linkSections (no quickLinks)", () => {
+    render(<QuickLinksWidget links={[]} linkSections={sampleSections} />);
+    expect(screen.getByText("Socials")).toBeTruthy();
+    expect(screen.getByText("Twitter/X")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Port all categorized links from old site config into 7 day configs with collapsible section headers
- Add CalendarWidget with ICS proxy, localStorage caching (15min TTL), loading/error/empty states
- All real URLs from old-site-reference/config/sites.json, no placeholder URLs

Closes #3

## Changes

### Part 1: Link Sections
- `LinkSection` interface added to `src/config/types.ts`
- `QuickLinksWidget` updated with collapsible sections using Preact state
- All 7 day configs populated: weekdays (Socials, Professional), weekends (Socials, Sports News, Sports Betting, Fantasy Sports), Sunday has all 5 sections

### Part 2: Calendar Widget MVP
- `ical.js` installed for ICS feed parsing
- `api/calendar-proxy.ts` Vercel serverless function with domain allowlist
- `CalendarWidget.tsx` with loading skeleton, empty state, error fallback, localStorage caching
- `src/config/calendar.ts` with empty sources array (configure ICS URLs to activate)

## Test plan
- [x] All 181 tests pass (14 test files)
- [x] New tests: LinkSection rendering, collapse/expand, CalendarWidget states, cache handling
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Eval score: 0.9 (threshold: 0.8)
- [x] Smoke test passes (`data-day` present in built HTML)
- [ ] Manual verification of link sections on live site
- [ ] Manual verification of calendar widget empty state