### PR TITLE
Add accessibility: aria labels, contrast fixes, reduced motion

### DIFF
--- a/src/components/modules/CookingModules.tsx
+++ b/src/components/modules/CookingModules.tsx
@@ -32,9 +32,9 @@ export function TonightHero({ size = "large" }: { size?: string }) {
           <div className="leading-relaxed mt-3" style={{ fontSize: "12.5px", color: "rgba(243,230,211,0.85)" }}>{t.note}</div>
 
           <div className="flex items-center gap-2 mt-auto" style={{ paddingTop: 16 }}>
-            <button className="font-mono rounded-md" style={{ fontSize: "11px", padding: "6px 12px", background: "#d97a3a", color: "#1a1410" }}>Start cooking mode</button>
-            <button className="font-mono rounded-md hairline" style={{ fontSize: "11px", padding: "6px 12px" }}>Recipe ↗</button>
-            <button className="font-mono rounded-md hairline" style={{ fontSize: "11px", padding: "6px 12px" }}>Kitchen playlist ▶</button>
+            <button aria-label="Start cooking mode" className="font-mono rounded-md" style={{ fontSize: "11px", padding: "6px 12px", background: "#d97a3a", color: "#1a1410" }}>Start cooking mode</button>
+            <button aria-label="Open recipe" className="font-mono rounded-md hairline" style={{ fontSize: "11px", padding: "6px 12px" }}>Recipe ↗</button>
+            <button aria-label="Play kitchen playlist" className="font-mono rounded-md hairline" style={{ fontSize: "11px", padding: "6px 12px" }}>Kitchen playlist ▶</button>
           </div>
         </div>
       </div>
@@ -47,7 +47,7 @@ export function RecipeShelf() {
     <div className="module p-4 module-enter" style={{ animationDelay: "140ms" }}>
       <div className="flex items-baseline justify-between mb-3">
         <div className="font-mono uppercase text-muted" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Saved · recently</div>
-        <button className="font-mono text-muted" style={{ fontSize: "10.5px" }}>All ↗</button>
+        <button aria-label="View all saved recipes" className="font-mono text-muted" style={{ fontSize: "10.5px" }}>All ↗</button>
       </div>
       <div className="space-y-2.5">
         {RECIPES.map((r, i) => (
@@ -93,7 +93,7 @@ export function GroceriesModule() {
           </div>
         ))}
       </div>
-      <button className="mt-3 font-mono rounded-md hairline w-full" style={{ fontSize: "11px", padding: "6px 12px" }}>Send to Instacart ↗</button>
+      <button aria-label="Send grocery list to Instacart" className="mt-3 font-mono rounded-md hairline w-full" style={{ fontSize: "11px", padding: "6px 12px" }}>Send to Instacart ↗</button>
     </div>
   );
 }

--- a/src/components/modules/LifeModules.tsx
+++ b/src/components/modules/LifeModules.tsx
@@ -353,7 +353,7 @@ export function NowPlaying(): JSX.Element {
         </div>
         <div className="flex-1 min-w-0">
           <div className="font-mono uppercase text-muted flex items-center gap-1.5" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>
-            <span className="live-dot" style={{ background: "#7adfff" }} />
+            <span className="live-dot" style={{ background: "#7adfff" }} /><span className="sr-only">Live</span>
             Now playing · {np.source}
           </div>
           <div className="font-medium font-serif italic leading-tight mt-0.5 truncate" style={{ fontSize: "13px" }}>
@@ -363,12 +363,14 @@ export function NowPlaying(): JSX.Element {
         </div>
         <div className="flex items-center gap-2">
           <button
+            aria-label="Pause"
             className="hairline rounded-full flex items-center justify-center"
             style={{ width: 28, height: 28 }}
           >
             <Icon name="pause" size={12} />
           </button>
           <button
+            aria-label="Skip to next track"
             className="hairline rounded-full flex items-center justify-center"
             style={{ width: 28, height: 28 }}
           >
@@ -444,6 +446,7 @@ export function PinnedRow({ pins = [] }: PinnedRowProps): JSX.Element {
       {pins.map((p, i) => (
         <button
           key={i}
+          aria-label={`Open ${p.n}`}
           className="tile hairline rounded-md px-2.5 py-1.5 flex items-center gap-1.5"
           style={{ background: "rgba(255,255,255,0.03)" }}
         >

--- a/src/components/modules/SportsModules.tsx
+++ b/src/components/modules/SportsModules.tsx
@@ -56,7 +56,7 @@ export function GameRow({ g, dense = false }: { g: Game; dense?: boolean }) {
         </div>
       )}
       <div className="flex items-center gap-1.5 justify-end" style={{ width: 78 }}>
-        {g.live && <span className="live-dot" />}
+        {g.live && <><span className="live-dot" /><span className="sr-only">Live</span></>}
         <span className="font-mono tabnum" style={{ fontSize: "11px" }}>{g.state}</span>
       </div>
     </div>
@@ -97,7 +97,7 @@ export function SportsBoard({
       <div className="divider my-3" />
       <div className="flex items-center justify-between font-mono text-muted" style={{ fontSize: "10.5px" }}>
         <div>Tracking · NFL · NBA · MLB · CFB · CBB · EPL · UCL · F1 · PGA · ATP · UFC</div>
-        <button style={{ color: "inherit" }}>All games <Icon name="chevron" size={11} /></button>
+        <button aria-label="View all games" style={{ color: "inherit" }}>All games <Icon name="chevron" size={11} /></button>
       </div>
     </div>
   );
@@ -273,7 +273,7 @@ export function EventTakeover() {
           </div>
           <div className="flex items-center gap-2 mt-4">
             <span className="chip" style={{ background: "rgba(255,235,170,0.16)", borderColor: "rgba(255,235,170,0.3)", color: "#f4efd8" }}>
-              <span className="live-dot" />R3 LIVE on ESPN+
+              <span className="live-dot" /><span className="sr-only">Live</span>R3 LIVE on ESPN+
             </span>
             <span className="chip" style={{ background: "rgba(255,235,170,0.10)", borderColor: "rgba(255,235,170,0.22)", color: "#f4efd8" }}>
               Final round 2:00 ET CBS

--- a/src/components/modules/WorkModules.tsx
+++ b/src/components/modules/WorkModules.tsx
@@ -81,7 +81,7 @@ export function MeetingTimeline({ now = "10:18", phase = "day" }: { now?: string
             <div className="font-mono uppercase text-muted" style={{ fontSize: "11px", letterSpacing: "0.05em" }}>Up next · 10:00</div>
             <div className="font-medium leading-tight mt-0.5" style={{ fontSize: "14.5px" }}>1:1 with Priya · Inference EM</div>
           </div>
-          <button className="font-mono rounded-md" style={{ fontSize: "11px", padding: "6px 12px", background: "var(--rh)", color: "#fff" }}>
+          <button aria-label="Join Google Meet" className="font-mono rounded-md" style={{ fontSize: "11px", padding: "6px 12px", background: "var(--rh)", color: "#fff" }}>
             Join Meet ↗
           </button>
         </div>
@@ -190,12 +190,12 @@ export function DevQuicklaunch() {
       </div>
       <div className="grid grid-cols-3 gap-2">
         {tools.map(t => t.url ? (
-          <a key={t.name} href={t.url} target="_blank" rel="noopener noreferrer" className="tile hairline rounded-md py-2.5 flex flex-col items-center gap-1.5" style={{ background: "rgba(255,255,255,0.03)", textDecoration: "none", color: "inherit" }}>
+          <a key={t.name} href={t.url} target="_blank" rel="noopener noreferrer" aria-label={`Open ${t.name}`} className="tile hairline rounded-md py-2.5 flex flex-col items-center gap-1.5" style={{ background: "rgba(255,255,255,0.03)", textDecoration: "none", color: "inherit" }}>
             <Icon name={t.icon} size={16} />
             <div className="font-mono" style={{ fontSize: "10.5px" }}>{t.name}</div>
           </a>
         ) : (
-          <button key={t.name} className="tile hairline rounded-md py-2.5 flex flex-col items-center gap-1.5" style={{ background: "rgba(255,255,255,0.03)" }}>
+          <button key={t.name} aria-label={`Open ${t.name}`} className="tile hairline rounded-md py-2.5 flex flex-col items-center gap-1.5" style={{ background: "rgba(255,255,255,0.03)" }}>
             <Icon name={t.icon} size={16} />
             <div className="font-mono" style={{ fontSize: "10.5px" }}>{t.name}</div>
           </button>
@@ -221,7 +221,7 @@ export function WorkShortcuts() {
       <div className="font-mono uppercase mb-2 px-1" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Workspace</div>
       <div className="grid grid-cols-4 gap-1.5">
         {apps.map(a => (
-          <a key={a.n} href={a.url} target="_blank" rel="noopener noreferrer" className="tile hairline rounded-md py-2 flex flex-col items-center gap-1" style={{ background: "rgba(255,255,255,0.03)", textDecoration: "none", color: "inherit" }}>
+          <a key={a.n} href={a.url} target="_blank" rel="noopener noreferrer" aria-label={`Open ${a.n}`} className="tile hairline rounded-md py-2 flex flex-col items-center gap-1" style={{ background: "rgba(255,255,255,0.03)", textDecoration: "none", color: "inherit" }}>
             <Icon name={a.i} size={14} />
             <div className="font-mono" style={{ fontSize: "10px" }}>{a.n}</div>
           </a>

--- a/src/components/scenes/App.tsx
+++ b/src/components/scenes/App.tsx
@@ -116,6 +116,7 @@ export function App() {
       <TeamSwitcher current={teamNight} onChange={pickTeamNight} />
 
       <button onClick={() => setCmdkOpen(true)}
+        aria-label="Open command palette"
         className="fixed z-40 flex items-center gap-2 rounded-full"
         style={{
           bottom: 24, left: 24,
@@ -148,6 +149,8 @@ function SceneSwitcher({ current, onChange }: { current: number; onChange: (i: n
       }}>
       {SCENES.map((s, i) => (
         <button key={s.id} onClick={() => onChange(i)}
+          aria-label={`Switch to ${s.label} scene`}
+          aria-pressed={i === current}
           className="px-3 py-1.5 rounded-full transition-all"
           style={{
             background: i === current ? "rgba(255,255,255,0.16)" : "transparent",
@@ -175,6 +178,8 @@ function TeamSwitcher({ current, onChange }: { current: string | null; onChange:
       <span className="font-mono uppercase px-2.5" style={{ fontSize: "10px", letterSpacing: "0.18em", color: "rgba(255,255,255,0.55)" }}>Match</span>
       {TEAM_NIGHTS.map((t) => (
         <button key={t.id || "default"} onClick={() => onChange(t.id)}
+          aria-label={`Switch to ${t.label} theme`}
+          aria-pressed={t.id === current}
           className="px-3 py-1.5 rounded-full transition-all"
           style={{
             background: t.id === current ? "rgba(255,255,255,0.16)" : "transparent",

--- a/src/components/scenes/CmdK.tsx
+++ b/src/components/scenes/CmdK.tsx
@@ -98,6 +98,9 @@ export function CmdK({ open, onClose }: { open: boolean; onClose: () => void }) 
     return (
       <div onMouseEnter={() => setSel(i)}
         onClick={() => activateItem(it)}
+        role="option"
+        id={`cmdk-option-${i}`}
+        aria-selected={active}
         className={`flex items-center gap-3 px-4 py-2 cursor-pointer ${active ? "" : ""}`}
         style={{ borderRadius: 8, background: active ? "rgba(255,255,255,0.10)" : undefined }}>
         <div className="rounded-md flex items-center justify-center hairline flex-none" style={{ width: 28, height: 28, background: it.kind === "action" ? "rgba(255,180,80,0.18)" : "rgba(255,255,255,0.04)" }}>
@@ -124,12 +127,17 @@ export function CmdK({ open, onClose }: { open: boolean; onClose: () => void }) 
             onInput={(e: Event) => { setQ((e.target as HTMLInputElement).value); setSel(0); }}
             onKeyDown={onKey}
             placeholder="Search bookmarks, run actions..."
+            aria-label="Search bookmarks and actions"
+            role="combobox"
+            aria-expanded={true}
+            aria-controls="cmdk-listbox"
+            aria-activedescendant={flatList[sel] ? `cmdk-option-${sel}` : undefined}
             className="flex-1 text-white"
             style={{ background: "transparent", outline: "none", fontSize: "15px", border: "none", color: "#fff" }}
           />
           <span className="kbd">esc</span>
         </div>
-        <div className="overflow-y-auto scrolly py-2 text-white" style={{ maxHeight: "58vh" }}>
+        <div className="overflow-y-auto scrolly py-2 text-white" role="listbox" id="cmdk-listbox" style={{ maxHeight: "58vh" }}>
           {empty ? (
             <>
               {recents.length > 0 && (

--- a/src/styles/scenes.css
+++ b/src/styles/scenes.css
@@ -43,10 +43,16 @@ body {
 @keyframes rise { from { opacity:0; transform: translateY(8px) } to { opacity:1; transform: translateY(0) } }
 
 .scene-enter { opacity: 1; }
-@media (prefers-reduced-motion: reduce) {
-  .module-enter { animation: none !important; opacity: 1 !important; }
-}
 .module-enter { opacity: 1; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  .scene-enter, .module-enter { opacity: 1 !important; }
+}
 
 /* ─── Grain texture ─────────────────────────────────────────────── */
 .grain::after {
@@ -124,9 +130,9 @@ body {
 .scene-wknd-am .divider { background: linear-gradient(90deg, transparent, rgba(10,30,20,0.16), transparent); }
 .scene-wknd-am .hairline { border-color: rgba(10,30,20,0.10); }
 
-.text-muted { color: rgba(255,255,255,0.62); }
-.scene-wkdy-am .text-muted { color: rgba(40,30,20,0.62); }
-.scene-wknd-am .text-muted { color: rgba(10,30,20,0.62); }
+.text-muted { color: rgba(255,255,255,0.72); }
+.scene-wkdy-am .text-muted { color: rgba(40,30,20,0.72); }
+.scene-wknd-am .text-muted { color: rgba(10,30,20,0.72); }
 
 .scene-team { color: #f4efe7; }
 .team-auburn .module.work-accent,
@@ -288,6 +294,7 @@ body {
 /* ─── Misc ──────────────────────────────────────────────────────── */
 .cursor-pointer { cursor: pointer; }
 .transition-all { transition: all 300ms cubic-bezier(.22,1,.36,1); }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 
 /* ─── League colors ─────────────────────────────────────────────── */
 .lg-mlb { background: #0c2340; } .lg-nfl { background: #013369; }


### PR DESCRIPTION
Closes #32

## Changes
- Add descriptive `aria-label` attributes to all interactive buttons across App, CmdK, WorkModules, CookingModules, SportsModules, and LifeModules
- Add ARIA combobox pattern to CmdK: `role="combobox"` on input, `role="listbox"` on results container, `role="option"` with `aria-selected` on result rows
- Add `aria-pressed` to scene switcher and team switcher toggle buttons
- Bump `.text-muted` opacity from 0.62 to 0.72 across all scene variants for WCAG AA contrast compliance
- Add comprehensive `prefers-reduced-motion: reduce` media query that disables all animations and transitions globally
- Add `.sr-only` utility class and screen-reader-accessible "Live" text labels alongside red dot indicators in SportsModules and NowPlaying

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (181 tests)
- [x] `node eval/score.cjs` passes (0.9, threshold 0.8)
- [x] Smoke test passes