### PR TITLE
Security follow-ups + live weather integration

### DIFF
--- a/api/auth/session-util.ts
+++ b/api/auth/session-util.ts
@@ -19,13 +19,8 @@ function getSecret(): Buffer {
   if (!secret || secret.length < 32) {
     throw new Error("SESSION_SECRET must be at least 32 characters");
   }
-  return crypto.pbkdf2Sync(
-    secret,
-    "lukeinglis.me-homepage-session",
-    100000,
-    32,
-    "sha256",
-  );
+  const salt = process.env.SESSION_SALT || "lukeinglis.me-homepage-session";
+  return crypto.pbkdf2Sync(secret, salt, 100000, 32, "sha256");
 }
 
 function encrypt(data: string): string {
@@ -105,7 +100,7 @@ export function setSession(res: VercelResponse, data: SessionData): void {
     .join("; ");
 
   const hmac = getSessionHmac(data.email);
-  const hmacCookie = `${SIG_COOKIE_NAME}=${hmac}; Path=/; SameSite=Strict; Max-Age=${THIRTY_DAYS}${securePart}`;
+  const hmacCookie = `${SIG_COOKIE_NAME}=${hmac}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${THIRTY_DAYS}${securePart}`;
 
   const existing = res.getHeader("Set-Cookie");
   const cookies = existing

--- a/api/calendar-proxy.ts
+++ b/api/calendar-proxy.ts
@@ -44,11 +44,10 @@ export default async function handler(
   res: VercelResponse,
 ): Promise<void> {
   const origin = req.headers.origin || "";
-  const allowedOrigins = [
-    "https://lukeinglis.me",
-    "http://localhost:4321",
-    "http://localhost:3000",
-  ];
+  const allowedOrigins = ["https://lukeinglis.me"];
+  if (process.env.NODE_ENV !== "production") {
+    allowedOrigins.push("http://localhost:4321", "http://localhost:3000");
+  }
   if (allowedOrigins.includes(origin)) {
     res.setHeader("Access-Control-Allow-Origin", origin);
     res.setHeader("Access-Control-Allow-Credentials", "true");
@@ -88,6 +87,7 @@ export default async function handler(
     return;
   }
 
+  const MAX_SIZE = 5 * 1024 * 1024;
   try {
     const response = await fetch(fetchUrl, {
       headers: { Accept: "text/calendar" },
@@ -101,7 +101,18 @@ export default async function handler(
       return;
     }
 
+    const contentLength = response.headers.get("content-length");
+    if (contentLength && parseInt(contentLength, 10) > MAX_SIZE) {
+      res.status(413).json({ error: "Calendar file too large" });
+      return;
+    }
+
     const text = await response.text();
+    if (text.length > MAX_SIZE) {
+      res.status(413).json({ error: "Calendar file too large" });
+      return;
+    }
+
     res.setHeader("Content-Type", "text/calendar; charset=utf-8");
     res.status(200).send(text);
   } catch (err) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,12 +12,21 @@ export default function middleware(request: Request) {
   }
 
   const cookieHeader = request.headers.get("cookie") || "";
-  const hasSession = cookieHeader.includes("homepage_session=");
-  const hasSig = cookieHeader.includes("homepage_session_sig=");
+  const sessionCookie = extractCookie(cookieHeader, "homepage_session");
+  const sigCookie = extractCookie(cookieHeader, "homepage_session_sig");
 
-  if (!hasSession || !hasSig) {
+  if (!sessionCookie || sessionCookie.length < 10) {
     return Response.redirect(new URL("/login", request.url));
   }
+
+  if (!sigCookie || !/^[0-9a-f]{64}$/.test(sigCookie)) {
+    return Response.redirect(new URL("/login", request.url));
+  }
+}
+
+function extractCookie(header: string, name: string): string | null {
+  const match = header.match(new RegExp("(?:^|;\\s*)" + name + "=([^;]*)"));
+  return match ? decodeURIComponent(match[1]) : null;
 }
 
 export const config = {

--- a/src/components/modules/LifeModules.tsx
+++ b/src/components/modules/LifeModules.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'preact/hooks';
 import type { JSX } from 'preact';
 import { Icon } from '../scenes/Icons';
-import { WEATHER, MARKETS, NETWORTH, NEWS, NOW_PLAYING, SHOP, QUOTES } from '../../data/scene-data';
+import { MARKETS, NETWORTH, NEWS, NOW_PLAYING, SHOP, QUOTES } from '../../data/scene-data.js';
+import { fetchWeather, getCachedLocation, requestLocation } from '../../lib/weather-api.js';
+import type { WeatherData } from '../../lib/weather-api.js';
 
 // ---------------------------------------------------------------------------
 // useDetectedCity
@@ -165,50 +167,91 @@ export function Sparkline({ values, up }: SparklineProps): JSX.Element {
 // WeatherModule
 // ---------------------------------------------------------------------------
 
-interface WeatherModuleProps {
-  scene: string;
-}
+export function WeatherModule(): JSX.Element {
+  const [weather, setWeather] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
-export function WeatherModule({ scene }: WeatherModuleProps): JSX.Element {
-  const weatherKey: Record<string, string> = {
-    wkdy_am: "morning",
-    wkdy_pm: "evening",
-    wknd_am: "wknd_am",
-    wknd_pm: "wknd_pm",
-  };
-  const w = WEATHER[weatherKey[scene]];
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        let loc = getCachedLocation();
+        if (!loc) loc = await requestLocation();
+        const data = await fetchWeather(loc?.lat, loc?.lon);
+        if (!cancelled) {
+          setWeather(data);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setError(true);
+          setLoading(false);
+        }
+      }
+    }
+    load();
+    const interval = setInterval(load, 15 * 60 * 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
 
-  const hours: [string, number][] = scene.endsWith("_am")
-    ? [["6a", 54], ["8a", 58], ["10a", 62], ["12p", 66], ["2p", 70], ["4p", 69], ["6p", 65], ["8p", 60]]
-    : [["12p", 66], ["2p", 70], ["4p", 69], ["6p", 65], ["8p", 60], ["10p", 56], ["12a", 53], ["2a", 51]];
+  if (loading) {
+    return (
+      <div className="module p-4 module-enter" style={{ animationDelay: "60ms" }}>
+        <div className="flex items-center justify-between mb-2">
+          <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em", opacity: 0.6 }}>
+            Loading weather...
+          </div>
+        </div>
+        <div style={{ height: 60, background: "rgba(128,128,128,0.1)", borderRadius: 8 }} />
+      </div>
+    );
+  }
+
+  if (error || !weather) {
+    return (
+      <div className="module p-4 module-enter" style={{ animationDelay: "60ms" }}>
+        <div className="font-mono text-muted" style={{ fontSize: "11px" }}>Weather unavailable</div>
+      </div>
+    );
+  }
+
+  const temps = weather.hourlyTemps.map((h) => h.temp);
+  const minT = Math.min(...temps.filter(Number.isFinite));
+  const maxT = Math.max(...temps.filter(Number.isFinite));
+  const range = maxT - minT || 1;
 
   return (
     <div className="module p-4 module-enter" style={{ animationDelay: "60ms" }}>
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
-          <Icon name={w.icon} size={14} />
-          <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>{w.city}</div>
+          <Icon name={weather.icon} size={14} />
+          <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>{weather.city}</div>
         </div>
-        <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{w.cond}</div>
+        <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{weather.description}</div>
       </div>
       <div className="flex items-baseline gap-3">
-        <div className="font-serif leading-none tabnum" style={{ fontSize: "44px" }}>{w.t}°</div>
-        <div className="font-mono text-muted tabnum" style={{ fontSize: "11px" }}>{w.lo}° · {w.hi}°</div>
+        <div className="font-serif leading-none tabnum" style={{ fontSize: "44px" }}>{weather.temperature}°</div>
+        <div className="font-mono text-muted tabnum" style={{ fontSize: "11px" }}>{weather.lowTemp}° · {weather.highTemp}°</div>
       </div>
       <div className="mt-3 flex items-end gap-1.5" style={{ height: 42 }}>
-        {hours.map((h, i) => {
-          const pct = (h[1] - 48) / 26;
+        {weather.hourlyTemps.map((h, i) => {
+          const pct = (h.temp - minT) / range;
           return (
             <div key={i} className="flex-1 flex flex-col items-center gap-1">
               <div
                 className="w-full rounded-sm"
                 style={{
-                  height: `${pct * 100}%`,
+                  height: `${Math.max(pct, 0) * 100}%`,
                   minHeight: 6,
                   background: "linear-gradient(180deg, rgba(255,180,120,0.85), rgba(255,180,120,0.25))",
                 }}
               />
-              <div className="font-mono text-muted tabnum" style={{ fontSize: "9px" }}>{h[0]}</div>
+              <div className="font-mono text-muted tabnum" style={{ fontSize: "9px" }}>{h.hour}</div>
             </div>
           );
         })}

--- a/src/components/scenes/Scenes.tsx
+++ b/src/components/scenes/Scenes.tsx
@@ -50,7 +50,7 @@ export function SceneWeekdayAM({ teamNight, userName }: { teamNight: string | nu
       <div className="mt-8 grid grid-cols-12 gap-5">
         <div className="col-span-8"><MeetingTimeline now="08:18" phase="day" /></div>
         <div className="col-span-4 space-y-4">
-          <WeatherModule scene="wkdy_am" />
+          <WeatherModule />
           <MarketsModule phase="open" />
         </div>
       </div>
@@ -140,7 +140,7 @@ export function SceneWeekendAM({ teamNight, userName }: { teamNight: string | nu
         <div className="col-span-5 space-y-5">
           <MyTeamsRail />
           <FantasyModule />
-          <WeatherModule scene="wknd_am" />
+          <WeatherModule />
         </div>
       </div>
       <div className="mt-5 grid grid-cols-12 gap-5">

--- a/src/data/scene-data.ts
+++ b/src/data/scene-data.ts
@@ -201,21 +201,6 @@ export const MARKETS: MarketData[] = [
   { sym: "10Y", val: "4.42%", chg: "+3 bps", up: true, spark: [4,5,6,5,7,6,8,7,9,8,10,9] },
 ];
 
-export interface Weather {
-  t: number;
-  lo: number;
-  hi: number;
-  cond: string;
-  icon: string;
-  city: string;
-}
-
-export const WEATHER: Record<string, Weather> = {
-  morning: { t: 58, lo: 49, hi: 71, cond: "Partly cloudy", icon: "cloud-sun", city: "Boston" },
-  evening: { t: 64, lo: 49, hi: 71, cond: "Light rain", icon: "cloud-rain", city: "Boston" },
-  wknd_am: { t: 67, lo: 55, hi: 78, cond: "Sun & clouds", icon: "sun", city: "Boston" },
-  wknd_pm: { t: 61, lo: 55, hi: 78, cond: "Clear", icon: "moon", city: "Boston" },
-};
 
 export const NEWS: Record<string, string[]> = {
   bloomberg: [

--- a/src/lib/weather-api.ts
+++ b/src/lib/weather-api.ts
@@ -1,0 +1,169 @@
+const DEFAULT_LAT = 42.36;
+const DEFAULT_LON = -71.06;
+
+export interface WeatherData {
+  temperature: number;
+  weatherCode: number;
+  windSpeed: number;
+  description: string;
+  icon: string;
+  highTemp: number;
+  lowTemp: number;
+  hourlyTemps: { hour: string; temp: number }[];
+  city: string;
+}
+
+const WMO_CODES: Record<number, { description: string; icon: string }> = {
+  0: { description: "Clear sky", icon: "sun" },
+  1: { description: "Mainly clear", icon: "sun" },
+  2: { description: "Partly cloudy", icon: "cloud-sun" },
+  3: { description: "Overcast", icon: "cloud" },
+  45: { description: "Fog", icon: "cloud" },
+  48: { description: "Rime fog", icon: "cloud" },
+  51: { description: "Light drizzle", icon: "cloud-rain" },
+  53: { description: "Drizzle", icon: "cloud-rain" },
+  55: { description: "Heavy drizzle", icon: "cloud-rain" },
+  61: { description: "Light rain", icon: "cloud-rain" },
+  63: { description: "Rain", icon: "cloud-rain" },
+  65: { description: "Heavy rain", icon: "cloud-rain" },
+  71: { description: "Light snow", icon: "cloud" },
+  73: { description: "Snow", icon: "cloud" },
+  75: { description: "Heavy snow", icon: "cloud" },
+  80: { description: "Light showers", icon: "cloud-rain" },
+  81: { description: "Showers", icon: "cloud-rain" },
+  82: { description: "Heavy showers", icon: "cloud-rain" },
+  95: { description: "Thunderstorm", icon: "cloud-rain" },
+};
+
+export async function fetchWeather(
+  lat?: number,
+  lon?: number,
+): Promise<WeatherData> {
+  const latitude = lat ?? DEFAULT_LAT;
+  const longitude = lon ?? DEFAULT_LON;
+
+  const params = new URLSearchParams({
+    latitude: String(latitude),
+    longitude: String(longitude),
+    current: "temperature_2m,weather_code,wind_speed_10m",
+    hourly: "temperature_2m",
+    daily: "temperature_2m_max,temperature_2m_min",
+    temperature_unit: "fahrenheit",
+    wind_speed_unit: "mph",
+    timezone: "auto",
+    forecast_days: "1",
+  });
+
+  const response = await fetch(
+    "https://api.open-meteo.com/v1/forecast?" + params,
+  );
+  if (!response.ok) throw new Error("Weather fetch failed");
+
+  const data = await response.json();
+
+  const wmoCode = data.current?.weather_code ?? 0;
+  const wmo = WMO_CODES[wmoCode] || { description: "Unknown", icon: "cloud" };
+
+  const hourlyTemps: { hour: string; temp: number }[] = [];
+  const hours: string[] = data.hourly?.time ?? [];
+  const temps: number[] = data.hourly?.temperature_2m ?? [];
+  for (let i = 0; i < hours.length && i < 24; i += 2) {
+    const h = new Date(hours[i]).getHours();
+    const label =
+      h === 0
+        ? "12a"
+        : h < 12
+          ? h + "a"
+          : h === 12
+            ? "12p"
+            : h - 12 + "p";
+    const t = temps[i];
+    hourlyTemps.push({
+      hour: label,
+      temp: Number.isFinite(t) ? Math.round(t) : 0,
+    });
+  }
+
+  let city = "Boston";
+  try {
+    const geoRes = await fetch(
+      "https://geocoding-api.open-meteo.com/v1/reverse?" +
+        new URLSearchParams({
+          latitude: String(latitude),
+          longitude: String(longitude),
+          count: "1",
+          language: "en",
+          format: "json",
+        }),
+    );
+    const geoData = await geoRes.json();
+    const place = geoData?.results?.[0];
+    city = place?.name || place?.admin2 || place?.admin1 || "Boston";
+  } catch {
+    /* use default */
+  }
+
+  const temp = data.current?.temperature_2m;
+  const wind = data.current?.wind_speed_10m;
+  const hi = data.daily?.temperature_2m_max?.[0];
+  const lo = data.daily?.temperature_2m_min?.[0];
+
+  return {
+    temperature: Number.isFinite(temp) ? Math.round(temp) : 0,
+    weatherCode: wmoCode,
+    windSpeed: Number.isFinite(wind) ? Math.round(wind) : 0,
+    description: wmo.description,
+    icon: wmo.icon,
+    highTemp: Number.isFinite(hi) ? Math.round(hi) : 0,
+    lowTemp: Number.isFinite(lo) ? Math.round(lo) : 0,
+    hourlyTemps,
+    city,
+  };
+}
+
+const GEO_CACHE_KEY = "homepage_geo";
+const GEO_CACHE_TTL = 24 * 60 * 60 * 1000;
+
+export function getCachedLocation(): { lat: number; lon: number } | null {
+  try {
+    const cached = localStorage.getItem(GEO_CACHE_KEY);
+    if (!cached) return null;
+    const parsed = JSON.parse(cached);
+    if (Date.now() - parsed.timestamp > GEO_CACHE_TTL) return null;
+    return { lat: parsed.lat, lon: parsed.lon };
+  } catch {
+    return null;
+  }
+}
+
+export function cacheLocation(lat: number, lon: number): void {
+  try {
+    localStorage.setItem(
+      GEO_CACHE_KEY,
+      JSON.stringify({ lat, lon, timestamp: Date.now() }),
+    );
+  } catch {
+    /* quota exceeded */
+  }
+}
+
+export function requestLocation(): Promise<{
+  lat: number;
+  lon: number;
+} | null> {
+  return new Promise((resolve) => {
+    if (!navigator.geolocation) {
+      resolve(null);
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const loc = { lat: pos.coords.latitude, lon: pos.coords.longitude };
+        cacheLocation(loc.lat, loc.lon);
+        resolve(loc);
+      },
+      () => resolve(null),
+      { timeout: 5000, maximumAge: 300000 },
+    );
+  });
+}


### PR DESCRIPTION
Closes #54

## Summary
- **#49**: Add `HttpOnly` to HMAC signature cookie (safe for middleware since it reads raw `Cookie` header, not `document.cookie`)
- **#50**: Add 5MB response size limit on calendar proxy (checks both `Content-Length` header and body length)
- **#51**: Validate HMAC signature is a valid 64-char hex string in middleware (not just cookie presence)
- **#52**: Gate `localhost` CORS origins behind `NODE_ENV !== 'production'`
- **#53**: Read PBKDF2 salt from `SESSION_SALT` env var with backwards-compatible fallback
- **#20**: Replace static `WeatherModule` with live Open-Meteo API data. Browser geolocation with localStorage cache, Boston fallback, 15-minute auto-refresh

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (6/6)
- [x] `npm run lint` passes (0 errors)
- [x] Eval score meets threshold (0.45)