### PR TITLE
Update dashboard content to match real user profile

### DIFF
--- a/src/components/modules/CookingModules.tsx
+++ b/src/components/modules/CookingModules.tsx
@@ -93,7 +93,6 @@ export function GroceriesModule() {
           </div>
         ))}
       </div>
-      <button aria-label="Send grocery list to Instacart" className="mt-3 font-mono rounded-md hairline w-full" style={{ fontSize: "11px", padding: "6px 12px" }}>Send to Instacart ↗</button>
     </div>
   );
 }

--- a/src/components/modules/ExtraModules.tsx
+++ b/src/components/modules/ExtraModules.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '../scenes/Icons';
-import { MEETINGS } from '../../data/scene-data';
+import { MEETINGS, STREAMING } from '../../data/scene-data';
 import type { Meeting } from '../../data/scene-data';
 
 export function WorkCalendar({ phase = "day" }: { phase?: string }) {
@@ -185,31 +185,37 @@ export function YouTubeQueue({ scene = "wkdy_pm" }: { scene?: string }) {
 }
 
 export function StreamingShelf({ scene = "wknd_pm" }: { scene?: string }) {
+  const showKey = scene.startsWith("wknd") ? "wknd_pm" : "wkdy_pm";
+  const shows = STREAMING[showKey] || STREAMING.wkdy_pm;
+  const bgs = [
+    "linear-gradient(180deg,#0a2230,#040b10)",
+    "linear-gradient(180deg,#1a2030,#06080f)",
+    "linear-gradient(180deg,#3a1a0a,#100604)",
+    "linear-gradient(180deg,#1a1a2e,#070710)",
+  ];
   const rows = scene === "wknd_pm" ? [
     {
-      row: "Continue watching", items: [
-        { t: "Severance — S3E2", svc: "Apple TV+", left: "47m left", bg: "linear-gradient(180deg,#0a2230,#040b10)", new: true },
-        { t: "Slow Horses — S5E1", svc: "Apple TV+", left: "new", bg: "linear-gradient(180deg,#1a2030,#06080f)", new: true },
-        { t: "Industry — S4E3", svc: "HBO Max", left: "S4E3", bg: "linear-gradient(180deg,#3a0a0a,#100404)" },
-        { t: "Ripley", svc: "Netflix", left: "3 episodes", bg: "linear-gradient(180deg,#1a1a2e,#070710)" },
-      ]
+      row: "Continue watching", items: shows.map((s, i) => ({
+        t: s.title, svc: s.service, left: s.note,
+        bg: bgs[i % bgs.length],
+        new: s.badge === "NEW", live: false,
+      })),
     },
     {
       row: "Sports tonight on streaming", items: [
-        { t: "Wolves @ Nuggets G4", svc: "TNT · Max", left: "8:30 ET", bg: "linear-gradient(180deg,#0c2340,#236192)", live: true },
-        { t: "UFC 322 PPV", svc: "ESPN+", left: "10:00 ET", bg: "linear-gradient(180deg,#3a0606,#0e0202)" },
-        { t: "MLS · Galaxy v LAFC", svc: "Apple TV", left: "10:30 ET", bg: "linear-gradient(180deg,#1a1a1a,#000000)" },
-        { t: "F1 Miami · qualifying", svc: "F1 TV", left: "recap", bg: "linear-gradient(180deg,#3a0606,#100000)" },
+        { t: "Wolves @ Nuggets G4", svc: "TNT", left: "8:30 ET", bg: "linear-gradient(180deg,#0c2340,#236192)", live: true, new: false },
+        { t: "UFC 322 PPV", svc: "ESPN+", left: "10:00 ET", bg: "linear-gradient(180deg,#3a0606,#0e0202)", live: false, new: false },
+        { t: "MLS · Galaxy v LAFC", svc: "Apple TV", left: "10:30 ET", bg: "linear-gradient(180deg,#1a1a1a,#000000)", live: false, new: false },
+        { t: "F1 Miami · qualifying", svc: "F1 TV", left: "recap", bg: "linear-gradient(180deg,#3a0606,#100000)", live: false, new: false },
       ]
     },
   ] : [
     {
-      row: "Tonight's pick", items: [
-        { t: "Severance — S3E2", svc: "Apple TV+", left: "47m left", bg: "linear-gradient(180deg,#0a2230,#040b10)", new: true },
-        { t: "Slow Horses — S5E1", svc: "Apple TV+", left: "new", bg: "linear-gradient(180deg,#1a2030,#06080f)", new: true },
-        { t: "Industry — S4E3", svc: "HBO Max", left: "S4E3", bg: "linear-gradient(180deg,#3a0a0a,#100404)" },
-        { t: "Ripley", svc: "Netflix", left: "3 episodes", bg: "linear-gradient(180deg,#1a1a2e,#070710)" },
-      ]
+      row: "Tonight's pick", items: shows.map((s, i) => ({
+        t: s.title, svc: s.service, left: s.note,
+        bg: bgs[i % bgs.length],
+        new: s.badge === "NEW", live: false,
+      })),
     },
   ];
   return (

--- a/src/components/modules/LifeModules.tsx
+++ b/src/components/modules/LifeModules.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import type { JSX } from 'preact';
 import { Icon } from '../scenes/Icons';
-import { MARKETS, NETWORTH, NEWS, NOW_PLAYING, SHOP, QUOTES } from '../../data/scene-data.js';
+import { MARKETS, STOCKS, NEWS, NOW_PLAYING, QUOTES } from '../../data/scene-data.js';
 import { fetchWeather, getCachedLocation, requestLocation } from '../../lib/weather-api.js';
 import type { WeatherData } from '../../lib/weather-api.js';
 
@@ -142,10 +142,10 @@ export function Greeting({ name = "Luke" }: GreetingProps): JSX.Element {
 
 interface SparklineProps {
   values: number[];
-  up: boolean;
+  color: string;
 }
 
-export function Sparkline({ values, up }: SparklineProps): JSX.Element {
+export function Sparkline({ values, color }: SparklineProps): JSX.Element {
   const w = 60;
   const h = 22;
   const max = Math.max(...values);
@@ -158,7 +158,7 @@ export function Sparkline({ values, up }: SparklineProps): JSX.Element {
   const d = pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" ");
   return (
     <svg width={w} height={h}>
-      <path d={d} className="spark" stroke={up ? "#9ad59c" : "#f0978c"} strokeWidth="1.4" />
+      <path d={d} className="spark" stroke={color} strokeWidth="1.4" />
     </svg>
   );
 }
@@ -284,45 +284,30 @@ export function MarketsModule({ phase = "open" }: MarketsModuleProps): JSX.Eleme
           <div key={i} className="hairline rounded-md p-2.5" style={{ background: "rgba(255,255,255,0.03)" }}>
             <div className="flex items-baseline justify-between">
               <div className="font-mono uppercase text-muted" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>{m.sym}</div>
-              <div className="font-mono tabnum" style={{ fontSize: "10.5px", color: m.up ? "#9ad59c" : "#f0978c" }}>{m.chg}</div>
+              <div className="font-mono tabnum" style={{ fontSize: "10.5px", color: m.color }}>{m.chg}</div>
             </div>
             <div className="flex items-baseline justify-between mt-0.5">
               <div className="font-serif tabnum" style={{ fontSize: "18px" }}>{m.val}</div>
-              <Sparkline values={m.spark} up={m.up} />
+              <Sparkline values={m.data} color={m.color} />
             </div>
           </div>
         ))}
       </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// NetWorthModule
-// ---------------------------------------------------------------------------
-
-export function NetWorthModule(): JSX.Element {
-  return (
-    <div className="module p-4 module-enter" style={{ animationDelay: "140ms" }}>
-      <div className="font-mono uppercase text-muted mb-1" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>
-        Net worth · glance
-      </div>
-      <div className="font-serif leading-none tabnum mt-1" style={{ fontSize: "28px" }}>{NETWORTH.total}</div>
-      <div className="font-mono mt-1" style={{ fontSize: "10.5px", color: "#9ad59c" }}>{NETWORTH.delta}</div>
       <div className="divider my-3" />
-      <div className="space-y-1.5" style={{ fontSize: "12px" }}>
-        <div className="flex justify-between">
-          <span className="text-muted">Brokerage</span>
-          <span className="font-mono tabnum">$268.4k</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-muted">401(k)</span>
-          <span className="font-mono tabnum">$184.2k</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-muted">Cash</span>
-          <span className="font-mono tabnum">$34.6k</span>
-        </div>
+      <div className="flex items-center justify-between mb-2">
+        <div className="font-mono uppercase text-muted" style={{ fontSize: "10px", letterSpacing: "0.16em" }}>Portfolio · watchlist</div>
+        <div className="font-mono text-muted" style={{ fontSize: "10px" }}>{STOCKS.length} tickers</div>
+      </div>
+      <div className="grid grid-cols-3 gap-1.5">
+        {STOCKS.map((s, i) => (
+          <div key={i} className="hairline rounded-md px-2 py-1.5" style={{ background: "rgba(255,255,255,0.03)" }}>
+            <div className="font-mono uppercase" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>{s.sym}</div>
+            <div className="flex items-baseline justify-between mt-0.5">
+              <div className="font-mono tabnum" style={{ fontSize: "11px" }}>{s.val}</div>
+              <div className="font-mono tabnum" style={{ fontSize: "10px", color: s.color }}>{s.chg}</div>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -426,31 +411,6 @@ export function NowPlaying(): JSX.Element {
 }
 
 // ---------------------------------------------------------------------------
-// ShoppingModule
-// ---------------------------------------------------------------------------
-
-export function ShoppingModule(): JSX.Element {
-  return (
-    <div className="module p-4 module-enter" style={{ animationDelay: "240ms" }}>
-      <div className="flex items-center gap-2 mb-3">
-        <Icon name="shopping" size={14} />
-        <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>
-          Cart · wishlist
-        </div>
-      </div>
-      <div className="space-y-2">
-        {SHOP.map((s, i) => (
-          <div key={i} style={{ fontSize: "12.5px" }}>
-            <div className="font-serif">{s.what}</div>
-            <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{s.at} · {s.state}</div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // QuoteModule
 // ---------------------------------------------------------------------------
 
@@ -459,12 +419,12 @@ interface QuoteModuleProps {
 }
 
 export function QuoteModule({ idx = 0 }: QuoteModuleProps): JSX.Element {
-  const q = QUOTES[idx];
+  const q = QUOTES[idx % QUOTES.length];
   return (
     <div className="module-enter" style={{ animationDelay: "300ms" }}>
       <div className="font-serif italic leading-snug" style={{ maxWidth: 320, opacity: 0.78, fontSize: "16px" }}>
-        &ldquo;{q.q}&rdquo;{" "}
-        <span className="font-mono not-italic text-muted" style={{ fontSize: "10.5px" }}>{q.w}</span>
+        &ldquo;{q.text}&rdquo;{" "}
+        <span className="font-mono not-italic text-muted" style={{ fontSize: "10.5px" }}>{q.author}</span>
       </div>
     </div>
   );

--- a/src/components/modules/WorkModules.tsx
+++ b/src/components/modules/WorkModules.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '../scenes/Icons';
-import { MEETINGS, PROJECTS, INBOX, NOTES } from '../../data/scene-data';
+import { MEETINGS, PROJECTS, INBOX, NOTES, RED_HAT_NEWS } from '../../data/scene-data';
 import type { Meeting } from '../../data/scene-data';
 
 const TYPE_COLORS: Record<string, string> = {
@@ -174,12 +174,10 @@ export function NotesModule() {
 }
 
 export function DevQuicklaunch() {
-  const tools: { name: string; icon: string; url?: string }[] = [
+  const tools: { name: string; icon: string; url: string }[] = [
     { name: "Claude", icon: "claude", url: "https://claude.ai" },
     { name: "ChatGPT", icon: "sparkles", url: "https://chatgpt.com" },
     { name: "GitHub", icon: "github", url: "https://github.com" },
-    { name: "Granite", icon: "wand", url: "https://granite.chat" },
-    { name: "Terminal", icon: "command" },
     { name: "Jira", icon: "jira", url: "https://issues.redhat.com" },
   ];
   return (
@@ -188,17 +186,12 @@ export function DevQuicklaunch() {
         <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>LLM · Dev</div>
         <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>⌘K to search</div>
       </div>
-      <div className="grid grid-cols-3 gap-2">
-        {tools.map(t => t.url ? (
+      <div className="grid grid-cols-2 gap-2">
+        {tools.map(t => (
           <a key={t.name} href={t.url} target="_blank" rel="noopener noreferrer" aria-label={`Open ${t.name}`} className="tile hairline rounded-md py-2.5 flex flex-col items-center gap-1.5" style={{ background: "rgba(255,255,255,0.03)", textDecoration: "none", color: "inherit" }}>
             <Icon name={t.icon} size={16} />
             <div className="font-mono" style={{ fontSize: "10.5px" }}>{t.name}</div>
           </a>
-        ) : (
-          <button key={t.name} aria-label={`Open ${t.name}`} className="tile hairline rounded-md py-2.5 flex flex-col items-center gap-1.5" style={{ background: "rgba(255,255,255,0.03)" }}>
-            <Icon name={t.icon} size={16} />
-            <div className="font-mono" style={{ fontSize: "10.5px" }}>{t.name}</div>
-          </button>
         ))}
       </div>
     </div>
@@ -206,7 +199,7 @@ export function DevQuicklaunch() {
 }
 
 export function WorkShortcuts() {
-  const apps: { n: string; i: string; url?: string }[] = [
+  const apps: { n: string; i: string; url: string }[] = [
     { n: "Gmail", i: "mail", url: "https://mail.google.com" },
     { n: "Cal", i: "calendar", url: "https://calendar.google.com" },
     { n: "Drive", i: "doc", url: "https://drive.google.com" },
@@ -214,7 +207,6 @@ export function WorkShortcuts() {
     { n: "Slides", i: "slide", url: "https://slides.google.com" },
     { n: "Sheets", i: "sheet", url: "https://sheets.google.com" },
     { n: "Slack", i: "slack", url: "https://slack.com" },
-    { n: "Confl.", i: "bookmark", url: "https://confluence.com" },
   ];
   return (
     <div className="module p-3 module-enter" style={{ animationDelay: "240ms" }}>
@@ -239,9 +231,9 @@ export function RedHatNews() {
         <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Red Hat · internal</div>
       </div>
       <ul className="space-y-1.5" style={{ fontSize: "12.5px" }}>
-        <li>RHEL AI 1.5 GA freeze · Friday EOD</li>
-        <li>Q3 OKR draft circulated to Naren's staff</li>
-        <li>Summit: ticket allocations released</li>
+        {RED_HAT_NEWS.map((item, i) => (
+          <li key={i}>{item}</li>
+        ))}
       </ul>
     </div>
   );

--- a/src/components/scenes/Scenes.tsx
+++ b/src/components/scenes/Scenes.tsx
@@ -1,7 +1,7 @@
 import { MY_TEAMS_DETAIL } from '../../data/scene-data';
 import type { ComponentChildren } from 'preact';
 import { BgWeekdayAM, BgWeekdayPM, BgWeekendAM, BgWeekendPM, BgAuburn, BgChelsea, BgCamden } from './Backgrounds';
-import { Greeting, WeatherModule, MarketsModule, NetWorthModule, NewsModule, NowPlaying, QuoteModule, PinnedRow, ShoppingModule } from '../modules/LifeModules';
+import { Greeting, WeatherModule, MarketsModule, NewsModule, NowPlaying, QuoteModule, PinnedRow } from '../modules/LifeModules';
 import { MeetingTimeline, ProjectsModule, InboxModule, NotesModule, DevQuicklaunch, WorkShortcuts, RedHatNews } from '../modules/WorkModules';
 import { SportsBoard, MyTeamsRail, FantasyModule, EventTakeover, ScoreRecap, TeamDeepDive } from '../modules/SportsModules';
 import { TonightHero, GroceriesModule, WeekendMealPlan, SeasonalNote } from '../modules/CookingModules';
@@ -70,11 +70,10 @@ export function SceneWeekdayAM({ teamNight, userName }: { teamNight: string | nu
         </div>
       </div>
       <div className="mt-5 grid grid-cols-12 gap-5">
-        <div className="col-span-7"><NewsModule feeds={["bloomberg", "hn"]} hero="Fed minutes split the room: only one cut on the table for 2026." /></div>
-        <div className="col-span-3"><NetWorthModule /></div>
-        <div className="col-span-2 flex flex-col justify-between">
+        <div className="col-span-8"><NewsModule feeds={["bloomberg", "hn"]} hero="Fed minutes split the room: only one cut on the table for 2026." /></div>
+        <div className="col-span-4 flex flex-col justify-between">
           <QuoteModule idx={2} />
-          <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>Spring · Tuesday · day 124</div>
+          <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>Spring · Wednesday · day 127</div>
         </div>
       </div>
     </SceneShell>
@@ -146,8 +145,7 @@ export function SceneWeekendAM({ teamNight, userName }: { teamNight: string | nu
       <div className="mt-5 grid grid-cols-12 gap-5">
         <div className="col-span-5"><WeekendMealPlan /></div>
         <div className="col-span-4"><PersonalCalendar scene="wknd_am" /></div>
-        <div className="col-span-3 space-y-4">
-          <ShoppingModule />
+        <div className="col-span-3">
           <QuoteModule idx={1} />
         </div>
       </div>

--- a/src/data/scene-data.ts
+++ b/src/data/scene-data.ts
@@ -1,4 +1,4 @@
-export const TODAY = new Date(2026, 4, 3);
+export const TODAY = new Date(2026, 4, 7);
 
 export interface Meeting {
   t: string;
@@ -9,17 +9,17 @@ export interface Meeting {
 }
 
 export const MEETINGS: Meeting[] = [
-  { t: "08:30", end: "09:00", title: "Daily standup — Inference Platform", type: "team", join: true },
-  { t: "09:00", end: "10:00", title: "Focus block — RHEL AI roadmap doc", type: "focus" },
-  { t: "10:00", end: "10:30", title: "1:1 with Priya (EM, Inference)", type: "1on1", join: true },
-  { t: "10:30", end: "11:00", title: "Customer Council prep w/ Solutions", type: "team", join: true },
-  { t: "11:00", end: "12:00", title: "External — Banco Itaú design partner", type: "ext", join: true },
+  { t: "08:30", end: "09:00", title: "Daily standup — AI Innovation", type: "team", join: true },
+  { t: "09:00", end: "10:00", title: "Focus block — ITS Hub design doc", type: "focus" },
+  { t: "10:00", end: "10:30", title: "1:1 with manager", type: "1on1", join: true },
+  { t: "10:30", end: "11:00", title: "Training Hub sprint review", type: "team", join: true },
+  { t: "11:00", end: "12:00", title: "External — partner design session", type: "ext", join: true },
   { t: "12:00", end: "13:00", title: "Lunch / break", type: "break" },
-  { t: "13:00", end: "14:00", title: "RHEL AI 1.5 GA review (cross-team)", type: "team", join: true },
+  { t: "13:00", end: "14:00", title: "SDG Hub architecture review", type: "team", join: true },
   { t: "14:00", end: "15:00", title: "Focus block — Q3 OKR draft", type: "focus" },
-  { t: "15:00", end: "15:30", title: "Hiring loop — Sr. PM, Model Serving", type: "team", join: true },
+  { t: "15:00", end: "15:30", title: "Hiring loop — Sr. PM, AI Platform", type: "team", join: true },
   { t: "15:30", end: "16:00", title: "Open", type: "open" },
-  { t: "16:00", end: "17:00", title: "Exec readout — Inference platform GA", type: "ext", join: true },
+  { t: "16:00", end: "17:00", title: "Exec readout — AI Innovation platform", type: "ext", join: true },
 ];
 
 export interface Project {
@@ -31,10 +31,10 @@ export interface Project {
 }
 
 export const PROJECTS: Project[] = [
-  { name: "RHEL AI 1.5 — GA", status: "On track", pct: 78, last: "12m ago", tag: "Inference" },
-  { name: "Inference Server multi-tenant", status: "At risk", pct: 41, last: "3h ago", tag: "Platform" },
+  { name: "Training Hub — GA readiness", status: "On track", pct: 82, last: "2h ago", tag: "AI Innovation" },
+  { name: "SDG Hub — multi-model support", status: "On track", pct: 65, last: "yesterday", tag: "AI Innovation" },
+  { name: "ITS Hub — inference-time scaling", status: "At risk", pct: 38, last: "3h ago", tag: "AI Innovation" },
   { name: "Customer Council — May cohort", status: "On track", pct: 62, last: "yesterday", tag: "GTM" },
-  { name: "Granite vLLM optimizer benchmark", status: "Discovery", pct: 18, last: "2d ago", tag: "Research" },
 ];
 
 export interface Note {
@@ -43,18 +43,18 @@ export interface Note {
 }
 
 export const NOTES: Note[] = [
-  { title: "2026-05-05 — daily", ago: "today" },
-  { title: "RHEL AI launch — narrative v3", ago: "yest" },
-  { title: "Council Q&A prep — Itaú", ago: "2d" },
-  { title: "Reading — speculative decoding", ago: "4d" },
+  { title: "2026-05-07 — daily", ago: "today" },
+  { title: "ITS Hub — scaling architecture v2", ago: "yest" },
+  { title: "Training Hub launch checklist", ago: "2d" },
+  { title: "Reading — inference-time compute", ago: "4d" },
 ];
 
 export const INBOX = {
-  unread: 23,
-  flagged: 4,
+  unread: 18,
+  flagged: 3,
   top: [
-    { from: "Priya Anand", subj: "Re: 1.5 GA — exec readout deck", when: "07:42" },
-    { from: "Marcus (Itaú)", subj: "Council agenda — questions", when: "07:11" },
+    { from: "AI Innovation Lead", subj: "Re: ITS Hub — exec readout deck", when: "07:42" },
+    { from: "Partner PM", subj: "Design session agenda — questions", when: "07:11" },
     { from: "Eng All-Hands", subj: "Friday demo signups close today", when: "06:58" },
   ],
 };
@@ -111,8 +111,8 @@ export interface FantasyLeague {
 }
 
 export const FANTASY: FantasyLeague[] = [
-  { league: "Sleeper — The League", name: "Maple Bar Mafia", rec: "6-1", pts: 142.8, rank: "1st" },
-  { league: "ESPN — Fantasy Baseball", name: "Bird-Watchers", rec: "—", pts: "8th of 12", rank: "ROY: Holliday +14" },
+  { league: "Yahoo — Fantasy Football", name: "War Eagle Express", rec: "5-2", pts: 128.4, rank: "3rd" },
+  { league: "ESPN — Fantasy Baseball", name: "Bird-Watchers", rec: "—", pts: "6th of 12", rank: "Henderson hot" },
 ];
 
 export interface FantasyDeep {
@@ -127,11 +127,8 @@ export interface FantasyDeep {
 }
 
 export const FANTASY_DEEP: FantasyDeep[] = [
-  { platform: "Sleeper", sport: "NFL", league: "The League (work)", team: "Maple Bar Mafia", rec: "6-1 · 1st", status: "W", statusLabel: "Won wk 7 · 142.8", note: "Jefferson 31.4 · Hall 22.1 · Mahomes flat. Waiver: Tank Bigsby." },
-  { platform: "Sleeper", sport: "NFL", league: "Dynasty — College Friends", team: "War Damn Dynasty", rec: "4-3 · 5th", status: "L", statusLabel: "Lost wk 7 · 98.2", note: "Down to 3rd RB. Trade target: Tee Higgins for 2026 1st." },
-  { platform: "ESPN", sport: "NFL", league: "Family $ league", team: "Boston Punters", rec: "5-2 · 3rd", status: "P", statusLabel: "Pending MNF · -3.4", note: "Need Pacheco to clear 14.0. Brother starting Tucker — petty." },
-  { platform: "ESPN", sport: "MLB", league: "H2H Categories", team: "Bird-Watchers", rec: "4-3-1 · 8th of 12", status: "P", statusLabel: "Streaming 2 SP", note: "Henderson hot. ROY race: Holliday +14, Langford +9." },
-  { platform: "Yahoo", sport: "MLB", league: "Roto · 12 team", team: "Camden Hardballs", rec: "6th · 67.5 pts", status: "W", statusLabel: "Up 2 in saves", note: "Rotation thin — DL Strider till All-Star. Stash Crochet." },
+  { platform: "Yahoo", sport: "NFL", league: "Fantasy Football", team: "War Eagle Express", rec: "5-2 · 3rd", status: "W", statusLabel: "Won wk 7 · 128.4", note: "Jefferson 28.2 · Barkley 22.1. Waiver: target a TE." },
+  { platform: "ESPN", sport: "MLB", league: "H2H Categories", team: "Bird-Watchers", rec: "4-3-1 · 6th of 12", status: "P", statusLabel: "Streaming 2 SP", note: "Henderson hot. ROY race tightening." },
 ];
 
 export const TONIGHT = {
@@ -190,15 +187,34 @@ export interface MarketData {
   sym: string;
   val: string;
   chg: string;
-  up: boolean;
-  spark: number[];
+  color: string;
+  data: number[];
 }
 
 export const MARKETS: MarketData[] = [
-  { sym: "S&P 500", val: "5,284.42", chg: "+0.42%", up: true, spark: [10,12,11,14,13,16,15,18,17,20,19,22] },
-  { sym: "NASDAQ", val: "16,842.10", chg: "+0.71%", up: true, spark: [8,9,11,10,13,12,15,14,17,16,19,21] },
-  { sym: "DOW", val: "38,912.05", chg: "-0.08%", up: false, spark: [14,13,15,12,14,11,13,12,10,11,9,10] },
-  { sym: "10Y", val: "4.42%", chg: "+3 bps", up: true, spark: [4,5,6,5,7,6,8,7,9,8,10,9] },
+  { sym: "S&P 500", val: "5,284.42", chg: "+0.42%", color: "#4ade80", data: [62,64,63,65,66,64,67,68,66,69,70,68] },
+  { sym: "NASDAQ", val: "16,842.10", chg: "+0.71%", color: "#4ade80", data: [58,60,59,62,63,61,64,65,63,66,68,67] },
+  { sym: "DOW", val: "38,912.05", chg: "-0.08%", color: "#f87171", data: [70,69,71,70,68,69,67,68,70,69,68,67] },
+  { sym: "10Y", val: "4.42%", chg: "+3 bps", color: "#4ade80", data: [44,43,44,45,44,43,44,45,44,43,44,44] },
+];
+
+export interface StockData {
+  sym: string;
+  val: string;
+  chg: string;
+  color: string;
+}
+
+export const STOCKS: StockData[] = [
+  { sym: "MGM", val: "38.11", chg: "-0.26%", color: "#f87171" },
+  { sym: "PENN", val: "16.83", chg: "+0.48%", color: "#4ade80" },
+  { sym: "DAL", val: "73.24", chg: "-0.14%", color: "#f87171" },
+  { sym: "GE", val: "303.92", chg: "-0.63%", color: "#f87171" },
+  { sym: "GEV", val: "1,068.00", chg: "-4.55%", color: "#f87171" },
+  { sym: "JD", val: "30.26", chg: "-1.40%", color: "#f87171" },
+  { sym: "GEHC", val: "61.41", chg: "-0.51%", color: "#f87171" },
+  { sym: "HIVE", val: "2.84", chg: "-3.35%", color: "#f87171" },
+  { sym: "SNDL", val: "1.43", chg: "-0.69%", color: "#f87171" },
 ];
 
 
@@ -231,15 +247,31 @@ export const NEWS: Record<string, string[]> = {
 };
 
 export interface Quote {
-  q: string;
-  w: string;
+  text: string;
+  author: string;
 }
 
 export const QUOTES: Quote[] = [
-  { q: "Slow is smooth, smooth is fast.", w: "—" },
-  { q: "Begin again, lightly.", w: "Anne Lamott" },
-  { q: "The day is long; the year is short.", w: "Gretchen Rubin" },
-  { q: "First, do the hard thing.", w: "—" },
+  { text: "The obstacle is the way.", author: "Marcus Aurelius" },
+  { text: "We are what we repeatedly do. Excellence, then, is not an act, but a habit.", author: "Aristotle" },
+  { text: "The best time to plant a tree was 20 years ago. The second best time is now.", author: "Chinese Proverb" },
+  { text: "Simplicity is the ultimate sophistication.", author: "Leonardo da Vinci" },
+  { text: "Stay hungry, stay foolish.", author: "Steve Jobs" },
+  { text: "It is not the critic who counts.", author: "Theodore Roosevelt" },
+  { text: "Hard choices, easy life. Easy choices, hard life.", author: "Jerzy Gregorek" },
+  { text: "The only way to do great work is to love what you do.", author: "Steve Jobs" },
+  { text: "In the middle of difficulty lies opportunity.", author: "Albert Einstein" },
+  { text: "You miss 100% of the shots you do not take.", author: "Wayne Gretzky" },
+  { text: "War Eagle.", author: "Auburn Creed" },
+  { text: "Do not judge each day by the harvest you reap but by the seeds that you plant.", author: "Robert Louis Stevenson" },
+  { text: "The man who moves a mountain begins by carrying away small stones.", author: "Confucius" },
+  { text: "Fortune favors the bold.", author: "Virgil" },
+  { text: "What gets measured gets managed.", author: "Peter Drucker" },
+  { text: "Pressure is a privilege.", author: "Billie Jean King" },
+  { text: "The more I practice, the luckier I get.", author: "Gary Player" },
+  { text: "Be yourself; everyone else is already taken.", author: "Oscar Wilde" },
+  { text: "Not all those who wander are lost.", author: "J.R.R. Tolkien" },
+  { text: "First, solve the problem. Then, write the code.", author: "John Johnson" },
 ];
 
 export interface Bookmark {
@@ -345,23 +377,37 @@ export interface WatchlistItem {
 
 export const WATCHLIST: WatchlistItem[] = [
   { title: "Severance — S3E2", svc: "Apple TV+", left: "47m", new: true },
-  { title: "Ripley", svc: "Netflix", left: "3 ep" },
-  { title: "Slow Horses — S5", svc: "Apple TV+", left: "S5E1 new", new: true },
-  { title: "Industry — S4", svc: "HBO Max", left: "Sunday" },
+  { title: "Reacher — S3E5", svc: "Prime Video", left: "new", new: true },
+  { title: "The Bear — S4E1", svc: "Hulu", left: "premiere", new: true },
+  { title: "Yellowstone — S5E8", svc: "Peacock", left: "2 ep" },
 ];
 
-export const NETWORTH = { total: "$487,210", delta: "+$1,840 today", up: true };
-
-export interface ShopItem {
-  what: string;
-  at: string;
-  state: string;
+export interface StreamingShow {
+  title: string;
+  service: string;
+  badge: string | null;
+  note: string;
 }
 
-export const SHOP: ShopItem[] = [
-  { what: "Le Creuset 7¼ qt Dutch oven", at: "Williams-Sonoma", state: "in cart" },
-  { what: "Nike Pegasus 41", at: "Nike", state: "wishlist" },
-  { what: "Topo Designs daypack — 21L", at: "Topo Designs", state: "viewed Tue" },
+export const STREAMING: Record<string, StreamingShow[]> = {
+  wkdy_pm: [
+    { title: "Severance — S3E2", service: "Apple TV+", badge: "NEW", note: "47m left" },
+    { title: "Reacher — S3E5", service: "Prime Video", badge: "NEW", note: "new" },
+    { title: "The Bear — S4E1", service: "Hulu", badge: null, note: "S4 premiere" },
+    { title: "Yellowstone — S5E8", service: "Peacock", badge: null, note: "2 episodes" },
+  ],
+  wknd_pm: [
+    { title: "Severance — S3E2", service: "Apple TV+", badge: "NEW", note: "47m left" },
+    { title: "Lioness — S2E4", service: "Paramount+", badge: null, note: "S2E4" },
+    { title: "Reacher — S3E5", service: "Prime Video", badge: "NEW", note: "new" },
+    { title: "Dark Matter — S2E1", service: "Apple TV+", badge: null, note: "premiere" },
+  ],
+};
+
+export const RED_HAT_NEWS = [
+  "Training Hub GA freeze · Friday EOD",
+  "Q3 OKR draft circulated for review",
+  "Summit: AI Innovation demo allocations released",
 ];
 
 export interface TeamDetail {


### PR DESCRIPTION
Closes #56

## Summary
- Removed NetWorthModule and ShoppingModule from all 4 scene layouts, adjusted grid spans
- Removed Instacart button from GroceriesModule
- Updated work context to AI Innovation team (Training Hub, SDG Hub, ITS Hub)
- Updated shortcuts: removed Granite, Terminal, Confluence; kept Claude, ChatGPT, GitHub, Jira (2x2 grid) and 7 workspace apps
- Added individual stock watchlist (MGM, PENN, DAL, GE, GEV, JD, GEHC, HIVE, SNDL) to MarketsModule with compact grid
- Replaced streaming data with actual services (Apple TV+, Prime Video, Hulu, Peacock, Paramount+); removed HBO Max references
- Reduced fantasy leagues from 5 to 2 (Yahoo NFL, ESPN MLB)
- Expanded quotes from 4 to 20 diverse entries
- Updated meetings, inbox, notes, and Red Hat internal news content

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (6/6)
- [x] Eval score 0.6 (above 0.45 threshold; pre-existing infra failures unchanged)
- [ ] Visual check: verify all 4 scenes render correctly with updated content
- [ ] Verify no import errors from removed modules