### PR TITLE
Integrate Google Calendar, RSS news feeds, and live sports scores

### DIFF
--- a/api/auth/config.ts
+++ b/api/auth/config.ts
@@ -2,7 +2,7 @@ export const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 export const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 export const GOOGLE_USERINFO_URL =
   "https://www.googleapis.com/oauth2/v3/userinfo";
-export const SCOPES = "openid email profile";
+export const SCOPES = "openid email profile https://www.googleapis.com/auth/calendar.readonly";
 
 export function getRedirectUri(req: { headers: { host?: string } }): string {
   const host = req.headers.host;

--- a/api/calendar-google.ts
+++ b/api/calendar-google.ts
@@ -1,0 +1,114 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getSession } from "./auth/session-util.js";
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  if (req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const session = getSession(req);
+  if (!session || !session.accessToken) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const origin = req.headers.origin || "";
+  const allowedOrigins = ["https://lukeinglis.me"];
+  if (process.env.NODE_ENV !== "production") {
+    allowedOrigins.push("http://localhost:4321", "http://localhost:3000");
+  }
+  if (allowedOrigins.includes(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+  }
+  res.setHeader("Cache-Control", "no-store");
+
+  try {
+    const now = new Date();
+    const startOfDay = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+    );
+    const endOfDay = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() + 1,
+    );
+
+    const calListRes = await fetch(
+      "https://www.googleapis.com/calendar/v3/users/me/calendarList",
+      { headers: { Authorization: "Bearer " + session.accessToken } },
+    );
+
+    if (calListRes.status === 401) {
+      res.status(401).json({ error: "Token expired" });
+      return;
+    }
+    if (!calListRes.ok) {
+      res.status(502).json({ error: "Failed to fetch calendars" });
+      return;
+    }
+
+    const calList = await calListRes.json();
+    const calendars = calList.items || [];
+
+    const allEvents: {
+      title: string;
+      start: string;
+      end: string;
+      location: string;
+      meetLink: string;
+      calendarName: string;
+      calendarColor: string;
+      allDay: boolean;
+    }[] = [];
+
+    for (const cal of calendars) {
+      try {
+        const params = new URLSearchParams({
+          timeMin: startOfDay.toISOString(),
+          timeMax: endOfDay.toISOString(),
+          singleEvents: "true",
+          orderBy: "startTime",
+          maxResults: "20",
+        });
+        const eventsRes = await fetch(
+          "https://www.googleapis.com/calendar/v3/calendars/" +
+            encodeURIComponent(cal.id) +
+            "/events?" +
+            params,
+          { headers: { Authorization: "Bearer " + session.accessToken } },
+        );
+        if (eventsRes.ok) {
+          const eventsData = await eventsRes.json();
+          for (const event of eventsData.items || []) {
+            allEvents.push({
+              title: event.summary || "(No title)",
+              start: event.start?.dateTime || event.start?.date || "",
+              end: event.end?.dateTime || event.end?.date || "",
+              location: event.location || "",
+              meetLink: event.hangoutLink || "",
+              calendarName: cal.summary || "",
+              calendarColor: cal.backgroundColor || "",
+              allDay: !!event.start?.date,
+            });
+          }
+        }
+      } catch {
+        /* skip failed calendars */
+      }
+    }
+
+    allEvents.sort(
+      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+    );
+
+    res.json({ events: allEvents });
+  } catch {
+    res.status(500).json({ error: "Failed to fetch calendar events" });
+  }
+}

--- a/api/rss-proxy.ts
+++ b/api/rss-proxy.ts
@@ -1,0 +1,85 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getSession } from "./auth/session-util.js";
+
+const FEEDS: Record<string, string> = {
+  bloomberg: "https://feeds.bloomberg.com/markets/news.rss",
+  hn: "https://hnrss.org/frontpage",
+  nyt: "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
+  cnn: "http://rss.cnn.com/rss/cnn_topstories.rss",
+  espn: "https://www.espn.com/espn/rss/news",
+};
+
+interface FeedItem {
+  title: string;
+  link: string;
+  pubDate: string;
+}
+
+function parseRSS(xml: string): FeedItem[] {
+  const items: FeedItem[] = [];
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let match;
+  while ((match = itemRegex.exec(xml)) !== null && items.length < 5) {
+    const content = match[1];
+    const title =
+      content.match(
+        /<title>(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?<\/title>/,
+      )?.[1] || "";
+    const link =
+      content.match(
+        /<link>(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?<\/link>/,
+      )?.[1] || "";
+    const pubDate =
+      content.match(/<pubDate>(.*?)<\/pubDate>/)?.[1] || "";
+    if (title) items.push({ title: title.trim(), link: link.trim(), pubDate });
+  }
+  return items;
+}
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  if (req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const session = getSession(req);
+  if (!session || !session.email) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const origin = req.headers.origin || "";
+  const allowedOrigins = ["https://lukeinglis.me"];
+  if (process.env.NODE_ENV !== "production")
+    allowedOrigins.push("http://localhost:4321");
+  if (allowedOrigins.includes(origin))
+    res.setHeader("Access-Control-Allow-Origin", origin);
+
+  const feedId = typeof req.query.feed === "string" ? req.query.feed : "";
+  const feedUrl = FEEDS[feedId];
+  if (!feedUrl) {
+    res.status(400).json({
+      error: "Unknown feed. Available: " + Object.keys(FEEDS).join(", "),
+    });
+    return;
+  }
+
+  try {
+    const feedRes = await fetch(feedUrl, {
+      headers: { "User-Agent": "HomepageDashboard/1.0" },
+    });
+    if (!feedRes.ok) throw new Error("Feed fetch failed: " + feedRes.status);
+    const xml = await feedRes.text();
+    const items = parseRSS(xml);
+    res.setHeader(
+      "Cache-Control",
+      "s-maxage=300, stale-while-revalidate=600",
+    );
+    res.json({ feed: feedId, items });
+  } catch {
+    res.status(502).json({ error: "Failed to fetch feed" });
+  }
+}

--- a/api/sports-proxy.ts
+++ b/api/sports-proxy.ts
@@ -1,0 +1,113 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getSession } from "./auth/session-util.js";
+
+const LEAGUE_ENDPOINTS: Record<string, string> = {
+  mlb: "https://site.api.espn.com/apis/site/v2/sports/baseball/mlb/scoreboard",
+  nfl: "https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard",
+  nba: "https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard",
+  epl: "https://site.api.espn.com/apis/site/v2/sports/soccer/eng.1/scoreboard",
+  cfb: "https://site.api.espn.com/apis/site/v2/sports/football/college-football/scoreboard",
+  cbb: "https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/scoreboard",
+};
+
+const MY_TEAMS = ["AUB", "BAL", "CHE", "TB", "MIN"];
+
+interface GameInfo {
+  league: string;
+  away: string;
+  home: string;
+  awayScore: number | null;
+  homeScore: number | null;
+  state: string;
+  live: boolean;
+  network: string;
+  mine: boolean;
+}
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  if (req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const session = getSession(req);
+  if (!session || !session.email) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const origin = req.headers.origin || "";
+  const allowedOrigins = ["https://lukeinglis.me"];
+  if (process.env.NODE_ENV !== "production")
+    allowedOrigins.push("http://localhost:4321");
+  if (allowedOrigins.includes(origin))
+    res.setHeader("Access-Control-Allow-Origin", origin);
+
+  const games: GameInfo[] = [];
+
+  for (const [league, url] of Object.entries(LEAGUE_ENDPOINTS)) {
+    try {
+      const espnRes = await fetch(url, {
+        headers: { "User-Agent": "HomepageDashboard/1.0" },
+      });
+      if (!espnRes.ok) continue;
+      const data = await espnRes.json();
+
+      for (const event of data.events || []) {
+        const competition = event.competitions?.[0];
+        if (!competition) continue;
+
+        const competitors = competition.competitors || [];
+        const away = competitors.find(
+          (c: { homeAway: string }) => c.homeAway === "away",
+        );
+        const home = competitors.find(
+          (c: { homeAway: string }) => c.homeAway === "home",
+        );
+        if (!away || !home) continue;
+
+        const awayAbbr = away.team?.abbreviation || "";
+        const homeAbbr = home.team?.abbreviation || "";
+        const status = event.status || {};
+        const isLive = status.type?.state === "in";
+        const isFinal = status.type?.state === "post";
+        const statusText =
+          status.type?.shortDetail || status.type?.detail || "";
+
+        const isMine = MY_TEAMS.some(
+          (t) =>
+            awayAbbr.toUpperCase().includes(t) ||
+            homeAbbr.toUpperCase().includes(t),
+        );
+
+        const broadcast = competition.broadcasts?.[0]?.names?.[0] || "";
+
+        games.push({
+          league,
+          away: awayAbbr,
+          home: homeAbbr,
+          awayScore: isLive || isFinal ? Number(away.score) : null,
+          homeScore: isLive || isFinal ? Number(home.score) : null,
+          state: statusText,
+          live: isLive,
+          network: broadcast,
+          mine: isMine,
+        });
+      }
+    } catch {
+      /* skip failed leagues */
+    }
+  }
+
+  games.sort((a, b) => {
+    if (a.live !== b.live) return a.live ? -1 : 1;
+    if (a.mine !== b.mine) return a.mine ? -1 : 1;
+    return 0;
+  });
+
+  res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=120");
+  res.json({ games, lastUpdated: new Date().toISOString() });
+}

--- a/src/components/modules/ExtraModules.tsx
+++ b/src/components/modules/ExtraModules.tsx
@@ -1,8 +1,63 @@
+import { useState, useEffect } from 'preact/hooks';
 import { Icon } from '../scenes/Icons';
 import { MEETINGS, STREAMING } from '../../data/scene-data';
 import type { Meeting } from '../../data/scene-data';
+import { fetchCalendarEvents, formatEventTime } from '../../lib/calendar-api.js';
+import type { CalendarEvent } from '../../lib/calendar-api.js';
+
+function meetingDotColor(calColor: string): string {
+  if (!calColor) return "rgba(180,200,255,0.85)";
+  return calColor;
+}
 
 export function WorkCalendar({ phase = "day" }: { phase?: string }) {
+  const [liveEvents, setLiveEvents] = useState<CalendarEvent[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchCalendarEvents()
+      .then((events) => {
+        if (!cancelled) {
+          setLiveEvents(events);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (liveEvents && liveEvents.length > 0) {
+    const display = phase === "day" ? liveEvents.slice(0, 5) : liveEvents.slice(-2);
+    return (
+      <div className="module work-accent p-4 module-enter" style={{ animationDelay: "60ms" }}>
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <span className="rounded-full" style={{ width: 8, height: 8, background: "var(--rh)" }} />
+            <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Calendar · today</div>
+          </div>
+          <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{liveEvents.length} events</div>
+        </div>
+        <div className="space-y-1.5">
+          {display.map((ev, i) => (
+            <div key={i} className="flex items-baseline gap-3" style={{ fontSize: "12.5px" }}>
+              <span className="font-mono tabnum text-muted" style={{ fontSize: "11px", width: 52 }}>
+                {ev.allDay ? "All day" : formatEventTime(ev.start)}
+              </span>
+              <span className="rounded-full mt-1" style={{ width: 6, height: 6, background: meetingDotColor(ev.calendarColor) }} />
+              <span className="flex-1 truncate font-medium">{ev.title}</span>
+              {ev.meetLink && (
+                <a href={ev.meetLink} target="_blank" rel="noopener noreferrer" className="font-mono text-muted" style={{ fontSize: "10px" }}>join ↗</a>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   const meetings = MEETINGS;
   return (
     <div className="module work-accent p-4 module-enter" style={{ animationDelay: "60ms" }}>
@@ -11,7 +66,9 @@ export function WorkCalendar({ phase = "day" }: { phase?: string }) {
           <span className="rounded-full" style={{ width: 8, height: 8, background: "var(--rh)" }} />
           <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Work calendar · Red Hat</div>
         </div>
-        <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{phase === "day" ? "10 events" : "2 left"}</div>
+        <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>
+          {loading ? "Loading..." : phase === "day" ? "10 events" : "2 left"}
+        </div>
       </div>
       <div className="space-y-1.5">
         {(phase === "day" ? meetings.slice(0, 5) : meetings.slice(-2)).map((m: Meeting, i: number) => (
@@ -31,7 +88,17 @@ export function WorkCalendar({ phase = "day" }: { phase?: string }) {
 }
 
 export function PersonalCalendar({ scene }: { scene: string }) {
-  const items: Record<string, { t: string; what: string }[]> = {
+  const [liveEvents, setLiveEvents] = useState<CalendarEvent[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchCalendarEvents()
+      .then((events) => { if (!cancelled) setLiveEvents(events); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  const staticItems: Record<string, { t: string; what: string }[]> = {
     "wkdy_am": [
       { t: "7:00 AM", what: "Run · Esplanade loop · 4 mi" },
       { t: "6:45 PM", what: "Pickup — Lina from soccer" },
@@ -53,7 +120,35 @@ export function PersonalCalendar({ scene }: { scene: string }) {
       { t: "10:00 PM", what: "UFC 322 main · ESPN+ PPV" },
     ],
   };
-  const list = items[scene] || [];
+
+  if (liveEvents && liveEvents.length > 0) {
+    return (
+      <div className="module p-4 module-enter" style={{ animationDelay: "100ms" }}>
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <span className="rounded-full" style={{ width: 8, height: 8, background: "#9ad59c" }} />
+            <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Personal · life</div>
+          </div>
+          <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{liveEvents.length} on deck</div>
+        </div>
+        <div className="space-y-2">
+          {liveEvents.map((ev, i) => (
+            <div key={i} className="flex items-baseline gap-3" style={{ fontSize: "12.5px" }}>
+              <span className="font-mono tabnum text-muted flex-none" style={{ fontSize: "11px", width: 60 }}>
+                {ev.allDay ? "All day" : formatEventTime(ev.start)}
+              </span>
+              <span className="font-serif">
+                {ev.title}
+                {ev.location ? " · " + ev.location : ""}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const list = staticItems[scene] || [];
   return (
     <div className="module p-4 module-enter" style={{ animationDelay: "100ms" }}>
       <div className="flex items-center justify-between mb-3">

--- a/src/components/modules/LifeModules.tsx
+++ b/src/components/modules/LifeModules.tsx
@@ -4,6 +4,8 @@ import { Icon } from '../scenes/Icons';
 import { MARKETS, STOCKS, NEWS, NOW_PLAYING, QUOTES } from '../../data/scene-data.js';
 import { fetchWeather, getCachedLocation, requestLocation } from '../../lib/weather-api.js';
 import type { WeatherData } from '../../lib/weather-api.js';
+import { fetchNews } from '../../lib/news-api.js';
+import type { NewsItem } from '../../lib/news-api.js';
 
 // ---------------------------------------------------------------------------
 // useDetectedCity
@@ -331,11 +333,36 @@ const FEED_LABELS: Record<string, string> = {
 };
 
 export function NewsModule({ feeds = ["bloomberg", "hn"], hero = null }: NewsModuleProps): JSX.Element {
+  const [liveNews, setLiveNews] = useState<Record<string, NewsItem[]>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all(
+      feeds.map((f) =>
+        fetchNews(f)
+          .then((items) => ({ feed: f, items }))
+          .catch(() => ({ feed: f, items: [] as NewsItem[] }))
+      )
+    ).then((results) => {
+      if (cancelled) return;
+      const map: Record<string, NewsItem[]> = {};
+      for (const r of results) {
+        if (r.items.length > 0) map[r.feed] = r.items;
+      }
+      setLiveNews(map);
+      setLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [feeds.join(",")]);
+
+  const hasLive = Object.keys(liveNews).length > 0;
+
   return (
     <div className="module p-4 module-enter" style={{ animationDelay: "160ms" }}>
       <div className="flex items-center justify-between mb-3">
         <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>
-          News · curated
+          News · {hasLive ? "live" : "curated"}
         </div>
         <div className="flex gap-1">
           {feeds.map((f) => (
@@ -347,18 +374,31 @@ export function NewsModule({ feeds = ["bloomberg", "hn"], hero = null }: NewsMod
         <div className="font-serif leading-tight mb-3" style={{ fontSize: "18px" }}>{hero}</div>
       )}
       <div className="space-y-3">
-        {feeds.map((f) => (
-          <div key={f}>
-            <div className="font-mono uppercase text-muted mb-1.5" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>
-              {FEED_LABELS[f]}
+        {feeds.map((f) => {
+          const live = liveNews[f];
+          return (
+            <div key={f}>
+              <div className="font-mono uppercase text-muted mb-1.5" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>
+                {FEED_LABELS[f]}
+              </div>
+              <ul className="space-y-1.5">
+                {live ? (
+                  live.map((item, i) => (
+                    <li key={i} className="leading-snug" style={{ fontSize: "12.5px" }}>
+                      {item.link ? (
+                        <a href={item.link} target="_blank" rel="noopener noreferrer" className="hover-link">{item.title}</a>
+                      ) : item.title}
+                    </li>
+                  ))
+                ) : (
+                  (NEWS[f] || []).map((h, i) => (
+                    <li key={i} className="leading-snug" style={{ fontSize: "12.5px" }}>{h}</li>
+                  ))
+                )}
+              </ul>
             </div>
-            <ul className="space-y-1.5">
-              {(NEWS[f] || []).map((h, i) => (
-                <li key={i} className="leading-snug" style={{ fontSize: "12.5px" }}>{h}</li>
-              ))}
-            </ul>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/modules/SportsModules.tsx
+++ b/src/components/modules/SportsModules.tsx
@@ -1,7 +1,10 @@
+import { useState, useEffect } from 'preact/hooks';
 import type { ComponentChildren } from 'preact';
 import { Icon } from '../scenes/Icons';
 import { GAMES, FANTASY_DEEP, MY_TEAMS_DETAIL } from '../../data/scene-data';
 import type { Game, TeamDetail } from '../../data/scene-data';
+import { fetchScores } from '../../lib/sports-api.js';
+import type { GameInfo } from '../../lib/sports-api.js';
 
 const LG_LABEL: Record<string, string> = {
   mlb: "MLB", nfl: "NFL", nba: "NBA", cfb: "CFB", cbb: "CBB",
@@ -63,6 +66,42 @@ export function GameRow({ g, dense = false }: { g: Game; dense?: boolean }) {
   );
 }
 
+function LiveGameRow({ g }: { g: GameInfo }) {
+  const showScore = g.awayScore !== null;
+  const teamish = g.home ? g.away + " @ " + g.home : g.away;
+  return (
+    <div
+      className="flex items-center gap-3 py-2 px-2 rounded-md tile"
+      style={{ background: g.mine ? "rgba(255,180,80,0.06)" : "transparent" }}
+    >
+      <LeaguePip lg={g.league} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2">
+          <div className="font-medium leading-tight truncate" style={{ fontSize: "13px" }}>{teamish}</div>
+          {g.mine && (
+            <span className="font-mono uppercase" style={{ fontSize: "9px", letterSpacing: "0.05em", color: "#ffba6e" }}>
+              ★ mine
+            </span>
+          )}
+        </div>
+        <div className="text-muted truncate" style={{ fontSize: "11px" }}>{g.network}</div>
+      </div>
+      {showScore && (
+        <div
+          className="font-mono tabnum font-medium leading-none px-2.5 py-1 rounded hairline"
+          style={{ fontSize: "14px", background: "rgba(255,255,255,0.04)" }}
+        >
+          {g.awayScore}&ndash;{g.homeScore}
+        </div>
+      )}
+      <div className="flex items-center gap-1.5 justify-end" style={{ width: 78 }}>
+        {g.live && <><span className="live-dot" /><span className="sr-only">Live</span></>}
+        <span className="font-mono tabnum" style={{ fontSize: "11px" }}>{g.state}</span>
+      </div>
+    </div>
+  );
+}
+
 export function SportsBoard({
   slate = "weekday_evening",
   title = "What's on",
@@ -74,25 +113,51 @@ export function SportsBoard({
   subtitle?: string;
   hero?: ComponentChildren;
 }) {
-  const games = GAMES[slate];
+  const [liveGames, setLiveGames] = useState<GameInfo[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchScores()
+      .then((games) => {
+        if (!cancelled) {
+          setLiveGames(games);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const staticGames = GAMES[slate];
+  const hasLive = liveGames && liveGames.length > 0;
+  const liveCount = liveGames?.filter((g) => g.live).length || 0;
+
   return (
     <div className="module p-5 module-enter" style={{ animationDelay: "60ms" }}>
       <div className="flex items-baseline justify-between mb-3">
         <div>
           <div className="font-mono uppercase text-muted" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>
-            Sports · {title}
+            Sports · {hasLive ? "live scores" : title}
           </div>
-          <div className="font-serif leading-tight mt-0.5" style={{ fontSize: "22px" }}>{subtitle}</div>
+          <div className="font-serif leading-tight mt-0.5" style={{ fontSize: "22px" }}>
+            {hasLive && liveCount > 0
+              ? liveCount + " game" + (liveCount !== 1 ? "s" : "") + " in progress"
+              : subtitle}
+          </div>
         </div>
         <div className="flex items-center gap-1.5 font-mono text-muted" style={{ fontSize: "10.5px" }}>
-          <Icon name="tv" size={13} /> on TV now
+          {loading ? "Loading..." : <><Icon name="tv" size={13} /> on TV now</>}
         </div>
       </div>
       {hero}
       <div className="space-y-1">
-        {(games || []).map((g, i) => (
-          <GameRow key={i} g={g} />
-        ))}
+        {hasLive
+          ? liveGames.slice(0, 8).map((g, i) => <LiveGameRow key={i} g={g} />)
+          : (staticGames || []).map((g, i) => <GameRow key={i} g={g} />)
+        }
       </div>
       <div className="divider my-3" />
       <div className="flex items-center justify-between font-mono text-muted" style={{ fontSize: "10.5px" }}>
@@ -305,39 +370,79 @@ export function EventTakeover() {
 }
 
 export function ScoreRecap() {
-  const finals: { lg: string; line: string; sub: string; mine?: boolean }[] = [
+  const [liveGames, setLiveGames] = useState<GameInfo[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchScores()
+      .then((games) => { if (!cancelled) setLiveGames(games); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  const staticFinals: { lg: string; line: string; sub: string; mine?: boolean }[] = [
     { lg: "epl", line: "Chelsea 2 — Man City 1", sub: "Palmer brace · Stamford Bridge", mine: true },
     { lg: "mlb", line: "Orioles 6 — Red Sox 4", sub: "4-game sweep · Henderson 2 HR", mine: true },
     { lg: "cfb", line: "Auburn 24 — Georgia 17", sub: "OT · Iron Bowl tune-up", mine: true },
     { lg: "pga", line: "Masters R3 — Scheffler -14", sub: "Leads McIlroy by 2 entering Sun." },
     { lg: "f1", line: "Miami GP Q · Verstappen P1", sub: "Norris P2, Leclerc P3" },
   ];
+
+  const liveFinals = liveGames
+    ?.filter((g) => !g.live && g.awayScore !== null)
+    .slice(0, 5) || [];
+
+  const hasLive = liveFinals.length > 0;
+
   return (
     <div className="module p-5 module-enter" style={{ animationDelay: "60ms" }}>
       <div className="flex items-baseline justify-between mb-3">
         <div>
           <div className="font-mono uppercase text-muted" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Today's finals</div>
-          <div className="font-serif leading-tight mt-0.5" style={{ fontSize: "22px" }}>A good Saturday.</div>
+          <div className="font-serif leading-tight mt-0.5" style={{ fontSize: "22px" }}>
+            {hasLive ? liveFinals.length + " final" + (liveFinals.length !== 1 ? "s" : "") : "A good Saturday."}
+          </div>
         </div>
       </div>
       <div className="space-y-1">
-        {finals.map((f, i) => (
-          <div
-            key={i}
-            className="flex items-center gap-3 py-2 px-2 rounded-md tile"
-            style={{ background: f.mine ? "rgba(255,180,80,0.06)" : "transparent" }}
-          >
-            <LeaguePip lg={f.lg} />
-            <div className="flex-1">
-              <div className="font-medium leading-tight" style={{ fontSize: "13.5px" }}>{f.line}</div>
-              <div className="text-muted" style={{ fontSize: "11px" }}>{f.sub}</div>
+        {hasLive
+          ? liveFinals.map((g, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-3 py-2 px-2 rounded-md tile"
+              style={{ background: g.mine ? "rgba(255,180,80,0.06)" : "transparent" }}
+            >
+              <LeaguePip lg={g.league} />
+              <div className="flex-1">
+                <div className="font-medium leading-tight" style={{ fontSize: "13.5px" }}>
+                  {g.away} {g.awayScore} — {g.home} {g.homeScore}
+                </div>
+                <div className="text-muted" style={{ fontSize: "11px" }}>{g.state} · {g.network}</div>
+              </div>
+              {g.mine && (
+                <span className="font-mono uppercase" style={{ fontSize: "9.5px", letterSpacing: "0.05em", color: "#ffba6e" }}>★</span>
+              )}
+              <span className="font-mono text-muted" style={{ fontSize: "11px" }}>FINAL</span>
             </div>
-            {f.mine && (
-              <span className="font-mono uppercase" style={{ fontSize: "9.5px", letterSpacing: "0.05em", color: "#ffba6e" }}>★</span>
-            )}
-            <span className="font-mono text-muted" style={{ fontSize: "11px" }}>FINAL</span>
-          </div>
-        ))}
+          ))
+          : staticFinals.map((f, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-3 py-2 px-2 rounded-md tile"
+              style={{ background: f.mine ? "rgba(255,180,80,0.06)" : "transparent" }}
+            >
+              <LeaguePip lg={f.lg} />
+              <div className="flex-1">
+                <div className="font-medium leading-tight" style={{ fontSize: "13.5px" }}>{f.line}</div>
+                <div className="text-muted" style={{ fontSize: "11px" }}>{f.sub}</div>
+              </div>
+              {f.mine && (
+                <span className="font-mono uppercase" style={{ fontSize: "9.5px", letterSpacing: "0.05em", color: "#ffba6e" }}>★</span>
+              )}
+              <span className="font-mono text-muted" style={{ fontSize: "11px" }}>FINAL</span>
+            </div>
+          ))
+        }
       </div>
     </div>
   );

--- a/src/lib/calendar-api.ts
+++ b/src/lib/calendar-api.ts
@@ -1,0 +1,51 @@
+export interface CalendarEvent {
+  title: string;
+  start: string;
+  end: string;
+  location: string;
+  meetLink: string;
+  calendarName: string;
+  calendarColor: string;
+  allDay: boolean;
+}
+
+const CACHE_KEY = "homepage_calendar";
+const CACHE_TTL = 5 * 60 * 1000;
+
+export async function fetchCalendarEvents(): Promise<CalendarEvent[]> {
+  try {
+    const cached = localStorage.getItem(CACHE_KEY);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      if (Date.now() - parsed.timestamp < CACHE_TTL) return parsed.events;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  const res = await fetch("/api/calendar-google");
+  if (!res.ok) throw new Error("Calendar fetch failed");
+  const data = await res.json();
+
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ events: data.events, timestamp: Date.now() }),
+    );
+  } catch {
+    /* quota */
+  }
+
+  return data.events;
+}
+
+export function formatEventTime(iso: string): string {
+  const d = new Date(iso);
+  const h = d.getHours();
+  const m = d.getMinutes();
+  const ampm = h >= 12 ? "PM" : "AM";
+  const hour = h % 12 || 12;
+  return m === 0
+    ? hour + " " + ampm
+    : hour + ":" + String(m).padStart(2, "0") + " " + ampm;
+}

--- a/src/lib/news-api.ts
+++ b/src/lib/news-api.ts
@@ -1,0 +1,41 @@
+export interface NewsItem {
+  title: string;
+  link: string;
+}
+
+const CACHE_KEY_PREFIX = "homepage_news_";
+const CACHE_TTL = 30 * 60 * 1000;
+
+export async function fetchNews(feedId: string): Promise<NewsItem[]> {
+  const cacheKey = CACHE_KEY_PREFIX + feedId;
+  try {
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      if (Date.now() - parsed.timestamp < CACHE_TTL) return parsed.items;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  const res = await fetch("/api/rss-proxy?feed=" + feedId);
+  if (!res.ok) throw new Error("News fetch failed");
+  const data = await res.json();
+  const items = (data.items || []).map(
+    (i: { title: string; link: string }) => ({
+      title: i.title,
+      link: i.link,
+    }),
+  );
+
+  try {
+    localStorage.setItem(
+      cacheKey,
+      JSON.stringify({ items, timestamp: Date.now() }),
+    );
+  } catch {
+    /* quota */
+  }
+
+  return items;
+}

--- a/src/lib/sports-api.ts
+++ b/src/lib/sports-api.ts
@@ -1,0 +1,41 @@
+export interface GameInfo {
+  league: string;
+  away: string;
+  home: string;
+  awayScore: number | null;
+  homeScore: number | null;
+  state: string;
+  live: boolean;
+  network: string;
+  mine: boolean;
+}
+
+const CACHE_KEY = "homepage_sports";
+const CACHE_TTL = 2 * 60 * 1000;
+
+export async function fetchScores(): Promise<GameInfo[]> {
+  try {
+    const cached = localStorage.getItem(CACHE_KEY);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      if (Date.now() - parsed.timestamp < CACHE_TTL) return parsed.games;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  const res = await fetch("/api/sports-proxy");
+  if (!res.ok) throw new Error("Sports fetch failed");
+  const data = await res.json();
+
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ games: data.games, timestamp: Date.now() }),
+    );
+  } catch {
+    /* quota */
+  }
+
+  return data.games;
+}


### PR DESCRIPTION
## Summary
- Google Calendar integration: added `calendar.readonly` OAuth scope, `api/calendar-google.ts` endpoint, and `calendar-api.ts` client hook. WorkCalendar/PersonalCalendar modules fetch real events with static fallback.
- RSS News feeds: added `api/rss-proxy.ts` with server-side XML parsing and `news-api.ts` client hook (30-min cache). NewsModule renders clickable live headlines with static fallback.
- Live Sports scores: added `api/sports-proxy.ts` proxying ESPN public API and `sports-api.ts` client hook (2-min cache). SportsBoard/ScoreRecap show real scores with static fallback.
- All new API endpoints require session authentication and restrict CORS origins.

Closes #58

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (6/6)
- [x] Eval score meets threshold (0.45)
- [ ] Verify calendar events load when authenticated with Google
- [ ] Verify RSS headlines appear and link out correctly
- [ ] Verify ESPN scores appear for tracked leagues
- [ ] Verify static fallback renders when not authenticated