### PR TITLE
Gmail inbox integration, calendar refinement, empty states for unconnected modules

### DIFF
--- a/api/auth/config.ts
+++ b/api/auth/config.ts
@@ -2,7 +2,7 @@ export const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 export const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 export const GOOGLE_USERINFO_URL =
   "https://www.googleapis.com/oauth2/v3/userinfo";
-export const SCOPES = "openid email profile https://www.googleapis.com/auth/calendar.readonly";
+export const SCOPES = "openid email profile https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/gmail.readonly";
 
 export function getRedirectUri(req: { headers: { host?: string } }): string {
   const host = req.headers.host;

--- a/api/gmail.ts
+++ b/api/gmail.ts
@@ -1,0 +1,130 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getSession } from "./auth/session-util.js";
+
+interface GmailLabel {
+  messagesTotal?: number;
+  messagesUnread?: number;
+  threadsTotal?: number;
+  threadsUnread?: number;
+}
+
+interface GmailHeader {
+  name: string;
+  value: string;
+}
+
+interface GmailMessage {
+  id: string;
+  payload?: {
+    headers?: GmailHeader[];
+  };
+  snippet?: string;
+  internalDate?: string;
+}
+
+function getHeader(headers: GmailHeader[], name: string): string {
+  const h = headers.find(
+    (h) => h.name.toLowerCase() === name.toLowerCase(),
+  );
+  return h?.value || "";
+}
+
+function extractSenderName(from: string): string {
+  const match = from.match(/^"?([^"<]+)"?\s*</);
+  if (match) return match[1].trim();
+  const emailMatch = from.match(/^([^@]+)@/);
+  if (emailMatch) return emailMatch[1];
+  return from;
+}
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  if (req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const session = getSession(req);
+  if (!session || !session.accessToken) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const origin = req.headers.origin || "";
+  const allowedOrigins = ["https://lukeinglis.me"];
+  if (process.env.NODE_ENV !== "production") {
+    allowedOrigins.push("http://localhost:4321", "http://localhost:3000");
+  }
+  if (allowedOrigins.includes(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+  }
+  res.setHeader("Cache-Control", "no-store");
+
+  const authHeader = { Authorization: "Bearer " + session.accessToken };
+
+  try {
+    const [inboxRes, starredRes, msgsRes] = await Promise.all([
+      fetch(
+        "https://gmail.googleapis.com/gmail/v1/users/me/labels/INBOX",
+        { headers: authHeader },
+      ),
+      fetch(
+        "https://gmail.googleapis.com/gmail/v1/users/me/labels/STARRED",
+        { headers: authHeader },
+      ),
+      fetch(
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages?labelIds=INBOX&maxResults=5",
+        { headers: authHeader },
+      ),
+    ]);
+
+    if (inboxRes.status === 401) {
+      res.status(401).json({ error: "Token expired" });
+      return;
+    }
+
+    if (!inboxRes.ok || !starredRes.ok || !msgsRes.ok) {
+      res.status(502).json({ error: "Failed to fetch Gmail data" });
+      return;
+    }
+
+    const inboxLabel: GmailLabel = await inboxRes.json();
+    const starredLabel: GmailLabel = await starredRes.json();
+    const msgsData = await msgsRes.json();
+
+    const messageIds: { id: string }[] = msgsData.messages || [];
+    const messages = await Promise.all(
+      messageIds.slice(0, 5).map(async (m) => {
+        const msgRes = await fetch(
+          "https://gmail.googleapis.com/gmail/v1/users/me/messages/" +
+            m.id +
+            "?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date",
+          { headers: authHeader },
+        );
+        if (!msgRes.ok) return null;
+        const msg: GmailMessage = await msgRes.json();
+        const headers = msg.payload?.headers || [];
+        const from = getHeader(headers, "From");
+        const subject = getHeader(headers, "Subject");
+        const date = getHeader(headers, "Date");
+        return {
+          id: msg.id,
+          from: extractSenderName(from),
+          subject: subject || "(no subject)",
+          date,
+          snippet: msg.snippet || "",
+        };
+      }),
+    );
+
+    res.json({
+      unread: inboxLabel.messagesUnread || 0,
+      starred: starredLabel.messagesTotal || 0,
+      messages: messages.filter(Boolean),
+    });
+  } catch {
+    res.status(500).json({ error: "Failed to fetch Gmail data" });
+  }
+}

--- a/src/components/modules/CookingModules.tsx
+++ b/src/components/modules/CookingModules.tsx
@@ -1,42 +1,13 @@
 import { Icon } from '../scenes/Icons';
-import { TONIGHT, RECIPES, GROCERIES, COOK_VIDEOS } from '../../data/scene-data';
+import { EmptyState } from './EmptyState';
+import { RECIPES, COOK_VIDEOS } from '../../data/scene-data';
 
 export function TonightHero({ size = "large" }: { size?: string }) {
-  const t = TONIGHT;
   return (
-    <div className="module warm p-0 overflow-hidden module-enter" style={{ animationDelay: "40ms" }}>
-      <div className="grid" style={{ gridTemplateColumns: size === "large" ? "1.05fr 1fr" : "1fr" }}>
-        <div className="relative" style={{
-          minHeight: size === "large" ? 280 : 200,
-          background: `repeating-linear-gradient(135deg, rgba(120,55,25,0.85) 0 16px, rgba(160,75,35,0.85) 16px 32px), linear-gradient(180deg, #d97a3a, #6e2d12)`,
-        }}>
-          <div className="absolute inset-0" style={{ background: "radial-gradient(ellipse at 30% 30%, rgba(255,210,150,0.35), transparent 60%)" }} />
-          <div className="absolute" style={{ left: 16, top: 16 }}>
-            <span className="chip" style={{ background: "rgba(0,0,0,0.35)", borderColor: "rgba(255,220,180,0.3)", color: "#ffe8c8" }}>Tonight · 5:45 PM start</span>
-          </div>
-          <div className="absolute font-mono uppercase" style={{ left: 16, bottom: 16, right: 16, fontSize: "10px", letterSpacing: "0.18em", color: "rgba(255,220,180,0.7)" }}>
-            [ hero plate · braise + polenta ]
-          </div>
-        </div>
-        <div className="p-5 flex flex-col">
-          <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em", color: "#caa67a" }}>Tonight's plan</div>
-          <div className="font-serif leading-tight mt-1.5" style={{ fontSize: "28px", lineHeight: 1.15, color: "#f3e6d3" }}>{t.title}</div>
-          <div className="italic mt-1" style={{ fontSize: "12.5px", color: "#caa67a", fontFamily: "var(--serif)" }}>{t.source}</div>
-
-          <div className="grid grid-cols-3 gap-3 mt-4">
-            <div><div className="font-mono text-muted uppercase" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>Prep</div><div className="font-serif" style={{ fontSize: "20px" }}>{t.prep}m</div></div>
-            <div><div className="font-mono text-muted uppercase" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>Cook</div><div className="font-serif" style={{ fontSize: "20px" }}>{Math.floor(t.cook / 60)}h {t.cook % 60}m</div></div>
-            <div><div className="font-mono text-muted uppercase" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>Serves</div><div className="font-serif" style={{ fontSize: "20px" }}>{t.serves}</div></div>
-          </div>
-
-          <div className="leading-relaxed mt-3" style={{ fontSize: "12.5px", color: "rgba(243,230,211,0.85)" }}>{t.note}</div>
-
-          <div className="flex items-center gap-2 mt-auto" style={{ paddingTop: 16 }}>
-            <button aria-label="Start cooking mode" className="font-mono rounded-md" style={{ fontSize: "11px", padding: "6px 12px", background: "#d97a3a", color: "#1a1410" }}>Start cooking mode</button>
-            <button aria-label="Open recipe" className="font-mono rounded-md hairline" style={{ fontSize: "11px", padding: "6px 12px" }}>Recipe ↗</button>
-            <button aria-label="Play kitchen playlist" className="font-mono rounded-md hairline" style={{ fontSize: "11px", padding: "6px 12px" }}>Kitchen playlist ▶</button>
-          </div>
-        </div>
+    <div className="module p-4 module-enter" style={{ animationDelay: "40ms" }}>
+      <div className="flex flex-col items-center justify-center gap-2.5" style={{ minHeight: size === "large" ? 120 : 80 }}>
+        <Icon name="chef" size={20} className="text-muted" />
+        <div className="font-mono text-muted" style={{ fontSize: "11px" }}>No recipe planned</div>
       </div>
     </div>
   );
@@ -71,30 +42,7 @@ export function RecipeShelf() {
 }
 
 export function GroceriesModule() {
-  const need = GROCERIES.filter(g => !g.x);
-  const have = GROCERIES.filter(g => g.x);
-  return (
-    <div className="module p-4 module-enter" style={{ animationDelay: "180ms" }}>
-      <div className="flex items-baseline justify-between mb-3">
-        <div className="font-mono uppercase text-muted" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Grocery list · for tonight</div>
-        <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{need.length} to get</div>
-      </div>
-      <div className="space-y-1.5">
-        {need.map((g, i) => (
-          <div key={i} className="flex items-center gap-2.5" style={{ fontSize: "13px" }}>
-            <span className="rounded-sm hairline" style={{ width: 14, height: 14 }} />
-            <span>{g.t}</span>
-          </div>
-        ))}
-        {have.map((g, i) => (
-          <div key={i} className="flex items-center gap-2.5 text-muted line-through" style={{ fontSize: "13px" }}>
-            <span className="rounded-sm" style={{ width: 14, height: 14, background: "rgba(180,140,90,0.6)" }} />
-            <span>{g.t}</span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return <EmptyState icon="shopping-cart" message="No grocery list" delay="180ms" />;
 }
 
 export function CookingVideos() {
@@ -138,23 +86,5 @@ export function SeasonalNote() {
 }
 
 export function WeekendMealPlan() {
-  return (
-    <div className="module p-4 module-enter" style={{ animationDelay: "160ms" }}>
-      <div className="font-mono uppercase text-muted mb-3" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Weekend menu</div>
-      <div className="space-y-2.5">
-        {[
-          { day: "Sat brunch", what: "Buttermilk pancakes, bacon, soft eggs", chip: "easy" },
-          { day: "Sat dinner", what: "Grilled spatchcock chicken, charred lemon", chip: "grill" },
-          { day: "Sun brunch", what: "Frittata — leftover greens & gruyère", chip: "clean-out" },
-          { day: "Sun dinner", what: "Short ribs over polenta", chip: "main event" },
-        ].map((m, i) => (
-          <div key={i} className="flex items-baseline gap-3">
-            <div className="font-mono uppercase text-muted flex-none" style={{ fontSize: "10px", letterSpacing: "0.05em", width: 80 }}>{m.day}</div>
-            <div className="font-serif flex-1" style={{ fontSize: "13px" }}>{m.what}</div>
-            <span className="chip">{m.chip}</span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return <EmptyState icon="utensils" message="No meal plan set" delay="160ms" />;
 }

--- a/src/components/modules/EmptyState.tsx
+++ b/src/components/modules/EmptyState.tsx
@@ -1,0 +1,18 @@
+import { Icon } from '../scenes/Icons';
+
+interface EmptyStateProps {
+  icon: string;
+  message: string;
+  delay?: string;
+}
+
+export function EmptyState({ icon, message, delay = "100ms" }: EmptyStateProps) {
+  return (
+    <div className="module p-4 module-enter" style={{ animationDelay: delay }}>
+      <div className="flex flex-col items-center justify-center py-4 gap-2.5">
+        <Icon name={icon} size={20} className="text-muted" />
+        <div className="font-mono text-muted" style={{ fontSize: "11px" }}>{message}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modules/ExtraModules.tsx
+++ b/src/components/modules/ExtraModules.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import { Icon } from '../scenes/Icons';
-import { MEETINGS, STREAMING } from '../../data/scene-data';
+import { EmptyState } from './EmptyState';
+import { MEETINGS } from '../../data/scene-data';
 import type { Meeting } from '../../data/scene-data';
 import { fetchCalendarEvents, formatEventTime } from '../../lib/calendar-api.js';
 import type { CalendarEvent } from '../../lib/calendar-api.js';
@@ -19,7 +20,11 @@ export function WorkCalendar({ phase = "day" }: { phase?: string }) {
     fetchCalendarEvents()
       .then((events) => {
         if (!cancelled) {
-          setLiveEvents(events);
+          const workEvents = events.filter((e) =>
+            e.calendarName.toLowerCase().includes("redhat") ||
+            e.calendarName.toLowerCase().includes("red hat"),
+          );
+          setLiveEvents(workEvents.length > 0 ? workEvents : null);
           setLoading(false);
         }
       })
@@ -36,7 +41,7 @@ export function WorkCalendar({ phase = "day" }: { phase?: string }) {
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
             <span className="rounded-full" style={{ width: 8, height: 8, background: "var(--rh)" }} />
-            <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Calendar · today</div>
+            <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Work calendar · Red Hat</div>
           </div>
           <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{liveEvents.length} events</div>
         </div>
@@ -54,6 +59,18 @@ export function WorkCalendar({ phase = "day" }: { phase?: string }) {
             </div>
           ))}
         </div>
+      </div>
+    );
+  }
+
+  if (!loading && !liveEvents) {
+    return (
+      <div className="module work-accent p-4 module-enter" style={{ animationDelay: "60ms" }}>
+        <div className="flex items-center gap-2 mb-3">
+          <span className="rounded-full" style={{ width: 8, height: 8, background: "var(--rh)" }} />
+          <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Work calendar · Red Hat</div>
+        </div>
+        <div className="font-mono text-muted" style={{ fontSize: "11px" }}>No work events today</div>
       </div>
     );
   }
@@ -93,7 +110,15 @@ export function PersonalCalendar({ scene }: { scene: string }) {
   useEffect(() => {
     let cancelled = false;
     fetchCalendarEvents()
-      .then((events) => { if (!cancelled) setLiveEvents(events); })
+      .then((events) => {
+        if (!cancelled) {
+          const personal = events.filter((e) =>
+            !e.calendarName.toLowerCase().includes("redhat") &&
+            !e.calendarName.toLowerCase().includes("red hat"),
+          );
+          setLiveEvents(personal.length > 0 ? personal : null);
+        }
+      })
       .catch(() => {});
     return () => { cancelled = true; };
   }, []);
@@ -137,10 +162,13 @@ export function PersonalCalendar({ scene }: { scene: string }) {
               <span className="font-mono tabnum text-muted flex-none" style={{ fontSize: "11px", width: 60 }}>
                 {ev.allDay ? "All day" : formatEventTime(ev.start)}
               </span>
-              <span className="font-serif">
+              <span className="font-serif flex-1 truncate">
                 {ev.title}
                 {ev.location ? " · " + ev.location : ""}
               </span>
+              {ev.meetLink && (
+                <a href={ev.meetLink} target="_blank" rel="noopener noreferrer" className="font-mono text-muted flex-none" style={{ fontSize: "10px" }}>join ↗</a>
+              )}
             </div>
           ))}
         </div>
@@ -170,176 +198,14 @@ export function PersonalCalendar({ scene }: { scene: string }) {
   );
 }
 
-interface VideoData {
-  title: string;
-  channel: string;
-  ch_handle: string;
-  durTotal: string;
-  durElapsed: string;
-  viewers: string;
-  thumb: string;
+export function YouTubeFrame() {
+  return <EmptyState icon="video" message="Connect YouTube" delay="60ms" />;
 }
 
-export function YouTubeFrame({ video, sub = "Watch while cooking", aspect = "16/9" }: { video?: VideoData; sub?: string; aspect?: string }) {
-  const v = video || {
-    title: "Kenji — The science of braising, in 12 minutes",
-    channel: "J. Kenji López-Alt", ch_handle: "@JKenjiLopezAlt",
-    durTotal: "12:04", durElapsed: "3:18", viewers: "1.2M views",
-    thumb: "linear-gradient(135deg, #4a2a18 0%, #1a0904 50%, #b35c2a 100%)",
-  };
-  return (
-    <div className="module p-0 overflow-hidden module-enter" style={{ animationDelay: "60ms" }}>
-      <div style={{ aspectRatio: aspect, background: v.thumb, position: "relative" }}>
-        <div className="absolute inset-0" style={{ background: "radial-gradient(circle at 30% 35%, rgba(255,200,140,0.45), transparent 60%)" }} />
-        <div className="absolute inset-0" style={{ background: "linear-gradient(180deg, transparent 50%, rgba(0,0,0,0.55))" }} />
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="rounded-full flex items-center justify-center" style={{
-            width: 64, height: 64, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(4px)",
-            border: "1px solid rgba(255,255,255,0.2)",
-          }}>
-            <Icon name="play" size={26} />
-          </div>
-        </div>
-        <div className="absolute flex items-center gap-1.5 font-mono uppercase text-white" style={{ top: 12, left: 12, fontSize: "10px", letterSpacing: "0.18em" }}>
-          <span className="live-dot" style={{ background: "#ff3b3b" }} />
-          <span style={{ background: "rgba(0,0,0,0.55)", padding: "2px 6px", borderRadius: 4 }}>YouTube · embed</span>
-        </div>
-        <div className="absolute font-mono text-white" style={{ top: 12, right: 12, fontSize: "10px", background: "rgba(0,0,0,0.55)", padding: "2px 6px", borderRadius: 4 }}>{v.durTotal}</div>
-        <div className="absolute inset-x-0" style={{ bottom: 0 }}>
-          <div className="rounded mx-3 mb-2" style={{ height: 3, background: "rgba(255,255,255,0.18)" }}>
-            <div style={{ width: "27%", height: "100%", background: "#ff3b3b", borderRadius: 2 }} />
-          </div>
-          <div className="px-3 pb-3 flex items-center justify-between font-mono" style={{ fontSize: "10px", color: "rgba(255,255,255,0.85)" }}>
-            <span className="tabnum">{v.durElapsed} / {v.durTotal}</span>
-            <span className="flex items-center gap-2">
-              <Icon name="pause" size={12} />
-              <Icon name="skip" size={12} />
-              <span className="tabnum">{v.viewers}</span>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div className="p-3.5">
-        <div className="font-mono uppercase text-muted mb-1" style={{ fontSize: "10px", letterSpacing: "0.16em" }}>{sub}</div>
-        <div className="font-serif leading-tight" style={{ fontSize: "16px" }}>{v.title}</div>
-        <div className="font-mono text-muted mt-1.5 flex items-center gap-2" style={{ fontSize: "10.5px" }}>
-          <span className="rounded-full inline-block" style={{ width: 16, height: 16, background: "linear-gradient(135deg,#5a2616,#a4533c)" }} />
-          <span>{v.channel} · {v.ch_handle}</span>
-        </div>
-      </div>
-    </div>
-  );
+export function YouTubeQueue() {
+  return <EmptyState icon="list" message="Connect YouTube" delay="160ms" />;
 }
 
-export function YouTubeQueue({ scene = "wkdy_pm" }: { scene?: string }) {
-  const queue = scene.startsWith("wknd")
-    ? [
-      { t: "NFL RedZone · Sunday Funday cuts", ch: "NFL", dur: "24:11" },
-      { t: "Tifo · How Chelsea won the Champions League by accident", ch: "Tifo Football", dur: "18:34" },
-      { t: "Jomboy · Orioles take 4 in a row, sweet swing breakdown", ch: "Jomboy Media", dur: "10:08" },
-      { t: "Sara Tanaka · Spring grilling — five sauces, one chicken", ch: "NYT Cooking", dur: "14:02" },
-      { t: "Drive to Survive · S7 trailer reaction", ch: "WTF1", dur: "9:48" },
-    ]
-    : [
-      { t: "Why polenta is better than mash", ch: "Ethan Chlebowski", dur: "9:41" },
-      { t: "Sunday gravy, Tuesday energy", ch: "Adam Ragusea", dur: "14:27" },
-      { t: "Ten-minute weeknight ramen, three ways", ch: "Made With Lau", dur: "11:50" },
-    ];
-  const bgs = [
-    "linear-gradient(135deg,#1a3a2a,#06120a)",
-    "linear-gradient(135deg,#0a2a4e,#02080f)",
-    "linear-gradient(135deg,#3a1f10,#0c0604)",
-    "linear-gradient(135deg,#3e2a18,#0e0604)",
-    "linear-gradient(135deg,#3a1010,#0a0000)",
-  ];
-  return (
-    <div className="module p-4 module-enter" style={{ animationDelay: "160ms" }}>
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2">
-          <Icon name="video" size={14} />
-          <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>YouTube · queue</div>
-        </div>
-        <button className="font-mono text-muted" style={{ fontSize: "10.5px" }}>All ↗</button>
-      </div>
-      <div className="space-y-2.5">
-        {queue.map((v, i) => (
-          <div key={i} className="flex gap-3">
-            <div className="rounded flex-none relative overflow-hidden" style={{ width: 68, height: 40, background: bgs[i] || bgs[0] }}>
-              <div className="absolute inset-0 flex items-center justify-center"><Icon name="play" size={14} /></div>
-              <div className="absolute font-mono" style={{ right: 4, bottom: 2, fontSize: "8.5px", color: "#fff", background: "rgba(0,0,0,0.7)", padding: "1px 3px", borderRadius: 2 }}>{v.dur}</div>
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="font-medium leading-tight" style={{ fontSize: "12px" }}>{v.t}</div>
-              <div className="font-mono text-muted mt-0.5" style={{ fontSize: "10.5px" }}>{v.ch}</div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-export function StreamingShelf({ scene = "wknd_pm" }: { scene?: string }) {
-  const showKey = scene.startsWith("wknd") ? "wknd_pm" : "wkdy_pm";
-  const shows = STREAMING[showKey] || STREAMING.wkdy_pm;
-  const bgs = [
-    "linear-gradient(180deg,#0a2230,#040b10)",
-    "linear-gradient(180deg,#1a2030,#06080f)",
-    "linear-gradient(180deg,#3a1a0a,#100604)",
-    "linear-gradient(180deg,#1a1a2e,#070710)",
-  ];
-  const rows = scene === "wknd_pm" ? [
-    {
-      row: "Continue watching", items: shows.map((s, i) => ({
-        t: s.title, svc: s.service, left: s.note,
-        bg: bgs[i % bgs.length],
-        new: s.badge === "NEW", live: false,
-      })),
-    },
-    {
-      row: "Sports tonight on streaming", items: [
-        { t: "Wolves @ Nuggets G4", svc: "TNT", left: "8:30 ET", bg: "linear-gradient(180deg,#0c2340,#236192)", live: true, new: false },
-        { t: "UFC 322 PPV", svc: "ESPN+", left: "10:00 ET", bg: "linear-gradient(180deg,#3a0606,#0e0202)", live: false, new: false },
-        { t: "MLS · Galaxy v LAFC", svc: "Apple TV", left: "10:30 ET", bg: "linear-gradient(180deg,#1a1a1a,#000000)", live: false, new: false },
-        { t: "F1 Miami · qualifying", svc: "F1 TV", left: "recap", bg: "linear-gradient(180deg,#3a0606,#100000)", live: false, new: false },
-      ]
-    },
-  ] : [
-    {
-      row: "Tonight's pick", items: shows.map((s, i) => ({
-        t: s.title, svc: s.service, left: s.note,
-        bg: bgs[i % bgs.length],
-        new: s.badge === "NEW", live: false,
-      })),
-    },
-  ];
-  return (
-    <div className="module p-4 module-enter" style={{ animationDelay: "180ms" }}>
-      <div className="flex items-center gap-2 mb-3">
-        <Icon name="tv" size={14} />
-        <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Streaming</div>
-      </div>
-      <div className="space-y-4">
-        {rows.map((r, ri) => (
-          <div key={ri}>
-            <div className="font-mono uppercase text-muted mb-2" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>{r.row}</div>
-            <div className="grid grid-cols-4 gap-2">
-              {r.items.map((it: { t: string; svc: string; left: string; bg: string; live?: boolean; new?: boolean }, i: number) => (
-                <div key={i} className="rounded-lg overflow-hidden tile hairline">
-                  <div className="relative" style={{ aspectRatio: "3/4", background: it.bg }}>
-                    {it.live && <div className="absolute" style={{ top: 8, left: 8 }}><span className="chip" style={{ background: "rgba(255,59,59,0.18)", borderColor: "rgba(255,59,59,0.4)", color: "#ffb0a8" }}><span className="live-dot" />LIVE</span></div>}
-                    {it.new && !it.live && <div className="absolute" style={{ top: 8, left: 8 }}><span className="chip" style={{ background: "rgba(122,223,255,0.16)", borderColor: "rgba(122,223,255,0.3)", color: "#bdeaff" }}>NEW</span></div>}
-                    <div className="absolute inset-x-0 p-2.5" style={{ bottom: 0, background: "linear-gradient(180deg, transparent, rgba(0,0,0,0.7))" }}>
-                      <div className="font-medium font-serif leading-tight" style={{ fontSize: "12px" }}>{it.t}</div>
-                      <div className="font-mono text-muted mt-0.5 flex justify-between" style={{ fontSize: "9.5px" }}><span>{it.svc}</span><span>{it.left}</span></div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+export function StreamingShelf() {
+  return <EmptyState icon="tv" message="Connect streaming services" delay="180ms" />;
 }

--- a/src/components/modules/LifeModules.tsx
+++ b/src/components/modules/LifeModules.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'preact/hooks';
 import type { JSX } from 'preact';
 import { Icon } from '../scenes/Icons';
-import { MARKETS, STOCKS, NEWS, NOW_PLAYING, QUOTES } from '../../data/scene-data.js';
+import { EmptyState } from './EmptyState';
+import { MARKETS, STOCKS, NEWS, QUOTES } from '../../data/scene-data.js';
 import { fetchWeather, getCachedLocation, requestLocation } from '../../lib/weather-api.js';
 import type { WeatherData } from '../../lib/weather-api.js';
 import { fetchNews } from '../../lib/news-api.js';
@@ -409,45 +410,7 @@ export function NewsModule({ feeds = ["bloomberg", "hn"], hero = null }: NewsMod
 // ---------------------------------------------------------------------------
 
 export function NowPlaying(): JSX.Element {
-  const np = NOW_PLAYING;
-  return (
-    <div className="module p-3 module-enter" style={{ animationDelay: "200ms" }}>
-      <div className="flex items-center gap-3">
-        <div
-          className="rounded flex-none relative overflow-hidden"
-          style={{ width: 48, height: 48, background: np.cover }}
-        >
-          <div className="absolute inset-0" style={{ boxShadow: "inset 0 0 18px rgba(0,0,0,0.4)" }} />
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="font-mono uppercase text-muted flex items-center gap-1.5" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>
-            <span className="live-dot" style={{ background: "#7adfff" }} /><span className="sr-only">Live</span>
-            Now playing · {np.source}
-          </div>
-          <div className="font-medium font-serif italic leading-tight mt-0.5 truncate" style={{ fontSize: "13px" }}>
-            {np.title}
-          </div>
-          <div className="font-mono text-muted truncate" style={{ fontSize: "10.5px" }}>{np.artist}</div>
-        </div>
-        <div className="flex items-center gap-2">
-          <button
-            aria-label="Pause"
-            className="hairline rounded-full flex items-center justify-center"
-            style={{ width: 28, height: 28 }}
-          >
-            <Icon name="pause" size={12} />
-          </button>
-          <button
-            aria-label="Skip to next track"
-            className="hairline rounded-full flex items-center justify-center"
-            style={{ width: 28, height: 28 }}
-          >
-            <Icon name="skip" size={12} />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+  return <EmptyState icon="headphones" message="Connect music service" delay="200ms" />;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/modules/SportsModules.tsx
+++ b/src/components/modules/SportsModules.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'preact/hooks';
 import type { ComponentChildren } from 'preact';
 import { Icon } from '../scenes/Icons';
-import { GAMES, FANTASY_DEEP, MY_TEAMS_DETAIL } from '../../data/scene-data';
+import { EmptyState } from './EmptyState';
+import { GAMES, MY_TEAMS_DETAIL } from '../../data/scene-data';
 import type { Game, TeamDetail } from '../../data/scene-data';
 import { fetchScores } from '../../lib/sports-api.js';
 import type { GameInfo } from '../../lib/sports-api.js';
@@ -274,42 +275,7 @@ export function TeamDeepDive({ team }: { team?: TeamDetail }) {
 }
 
 export function FantasyModule() {
-  return (
-    <div className="module p-4 module-enter" style={{ animationDelay: "180ms" }}>
-      <div className="flex items-baseline justify-between mb-3">
-        <div className="font-mono uppercase text-muted" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>
-          Fantasy · all leagues
-        </div>
-        <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>5 active</div>
-      </div>
-      <div className="space-y-2">
-        {FANTASY_DEEP.map((f, i) => (
-          <div key={i} className="hairline rounded-md p-2.5" style={{ background: "rgba(255,255,255,0.03)" }}>
-            <div className="flex items-baseline justify-between">
-              <div className="font-mono uppercase text-muted" style={{ fontSize: "10px", letterSpacing: "0.05em" }}>
-                {f.platform} · {f.sport} · {f.league}
-              </div>
-              <span
-                className="chip"
-                style={{
-                  background: f.status === "W" ? "rgba(154,213,156,0.15)" : f.status === "L" ? "rgba(240,151,140,0.15)" : "rgba(247,184,107,0.15)",
-                  borderColor: f.status === "W" ? "rgba(154,213,156,0.3)" : f.status === "L" ? "rgba(240,151,140,0.3)" : "rgba(247,184,107,0.3)",
-                  color: f.status === "W" ? "#9ad59c" : f.status === "L" ? "#f0978c" : "#f7b86b",
-                }}
-              >
-                {f.statusLabel}
-              </span>
-            </div>
-            <div className="flex items-baseline justify-between mt-1">
-              <div className="font-medium font-serif italic" style={{ fontSize: "13px" }}>{f.team}</div>
-              <div className="font-mono tabnum" style={{ fontSize: "11.5px" }}>{f.rec}</div>
-            </div>
-            <div className="text-muted mt-0.5" style={{ fontSize: "11px" }}>{f.note}</div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return <EmptyState icon="trophy" message="Connect fantasy leagues" delay="180ms" />;
 }
 
 export function EventTakeover() {

--- a/src/components/modules/WorkModules.tsx
+++ b/src/components/modules/WorkModules.tsx
@@ -1,6 +1,10 @@
+import { useState, useEffect } from 'preact/hooks';
 import { Icon } from '../scenes/Icons';
-import { MEETINGS, PROJECTS, INBOX, NOTES, RED_HAT_NEWS } from '../../data/scene-data';
+import { EmptyState } from './EmptyState';
+import { MEETINGS, INBOX } from '../../data/scene-data';
 import type { Meeting } from '../../data/scene-data';
+import { fetchInbox, formatEmailDate } from '../../lib/gmail-api.js';
+import type { GmailInbox } from '../../lib/gmail-api.js';
 
 const TYPE_COLORS: Record<string, string> = {
   team: "rgba(160,180,255,0.85)",
@@ -98,56 +102,89 @@ export function MeetingTimeline({ now = "10:18", phase = "day" }: { now?: string
 }
 
 export function ProjectsModule() {
-  const colors: Record<string, string> = { "On track": "#9ad59c", "At risk": "#f7b86b", "Discovery": "#9bb8ff" };
-  return (
-    <div className="module work-accent p-5 module-enter" style={{ animationDelay: "120ms" }}>
-      <div className="flex items-baseline justify-between mb-3">
-        <div className="font-mono uppercase text-muted" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Active workstreams</div>
-        <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>4 of 11</div>
-      </div>
-      <div className="space-y-3">
-        {PROJECTS.map((p, i) => (
-          <div key={i} className="hairline rounded-md p-3" style={{ background: "rgba(255,255,255,0.03)" }}>
-            <div className="flex items-baseline justify-between mb-1.5">
-              <div className="font-medium leading-tight" style={{ fontSize: "13.5px" }}>{p.name}</div>
-              <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{p.last}</div>
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="flex-1 rounded-full" style={{ height: 3, background: "rgba(255,255,255,0.10)" }}>
-                <div className="rounded-full" style={{ height: "100%", width: p.pct + "%", background: colors[p.status] }} />
-              </div>
-              <div className="font-mono tabnum text-right" style={{ fontSize: "10.5px", width: 36 }}>{p.pct}%</div>
-              <div className="chip" style={{ background: `color-mix(in oklch, ${colors[p.status]} 18%, transparent)`, borderColor: `color-mix(in oklch, ${colors[p.status]} 30%, transparent)` }}>{p.status}</div>
-            </div>
-            <div className="font-mono text-muted mt-1.5" style={{ fontSize: "10.5px" }}>{p.tag}</div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return <EmptyState icon="briefcase" message="Connect Jira to track projects" delay="120ms" />;
 }
 
 export function InboxModule({ compact = false }: { compact?: boolean }) {
-  const I = INBOX;
+  const [gmail, setGmail] = useState<GmailInbox | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchInbox()
+      .then((data) => { if (!cancelled) { setGmail(data); setLoading(false); } })
+      .catch(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className={`module ${compact ? "" : "work-accent"} p-4 module-enter`} style={{ animationDelay: "80ms" }}>
+        <div className="flex items-center gap-2 mb-3">
+          <Icon name="mail" size={14} />
+          <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Inbox</div>
+        </div>
+        <div className="space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="rounded" style={{ height: 16, background: "rgba(128,128,128,0.1)" }} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!gmail) {
+    const I = INBOX;
+    return (
+      <div className={`module ${compact ? "" : "work-accent"} p-4 module-enter`} style={{ animationDelay: "80ms" }}>
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Icon name="mail" size={14} />
+            <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Inbox</div>
+          </div>
+          <div className="flex items-center gap-2 font-mono" style={{ fontSize: "10.5px" }}>
+            <span className="chip">{I.unread} unread</span>
+          </div>
+        </div>
+        <div className="space-y-2">
+          {I.top.map((m, i) => (
+            <div key={i} className="flex items-baseline gap-3">
+              <div className="font-mono text-muted tabnum" style={{ fontSize: "10.5px", width: 40 }}>{m.when}</div>
+              <div className="font-medium truncate" style={{ fontSize: "12.5px", width: 120 }}>{m.from}</div>
+              <div className="text-muted truncate flex-1" style={{ fontSize: "12.5px" }}>{m.subj}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={`module ${compact ? "" : "work-accent"} p-4 module-enter`} style={{ animationDelay: "80ms" }}>
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <Icon name="mail" size={14} />
-          <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Work inbox</div>
+          <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Inbox</div>
         </div>
         <div className="flex items-center gap-2 font-mono" style={{ fontSize: "10.5px" }}>
-          <span className="chip">{I.unread} unread</span>
-          <span className="chip" style={{ background: "rgba(255,80,80,0.14)", borderColor: "rgba(255,80,80,0.3)", color: "#ffb0a8" }}>{I.flagged} urgent</span>
+          <span className="chip">{gmail.unread} unread</span>
+          <span className="chip">{gmail.starred} starred</span>
         </div>
       </div>
       <div className="space-y-2">
-        {I.top.map((m, i) => (
-          <div key={i} className="flex items-baseline gap-3">
-            <div className="font-mono text-muted tabnum" style={{ fontSize: "10.5px", width: 40 }}>{m.when}</div>
+        {gmail.messages.map((m, i) => (
+          <a
+            key={i}
+            href={"https://mail.google.com/mail/u/0/#inbox/" + m.id}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-baseline gap-3 hover-link"
+            style={{ textDecoration: "none", color: "inherit" }}
+          >
+            <div className="font-mono text-muted tabnum" style={{ fontSize: "10.5px", width: 40 }}>{formatEmailDate(m.date)}</div>
             <div className="font-medium truncate" style={{ fontSize: "12.5px", width: 120 }}>{m.from}</div>
-            <div className="text-muted truncate flex-1" style={{ fontSize: "12.5px" }}>{m.subj}</div>
-          </div>
+            <div className="text-muted truncate flex-1" style={{ fontSize: "12.5px" }}>{m.subject}</div>
+          </a>
         ))}
       </div>
     </div>
@@ -155,22 +192,7 @@ export function InboxModule({ compact = false }: { compact?: boolean }) {
 }
 
 export function NotesModule() {
-  return (
-    <div className="module p-4 module-enter" style={{ animationDelay: "160ms" }}>
-      <div className="flex items-center gap-2 mb-3">
-        <Icon name="obsidian" size={14} />
-        <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Obsidian · recent</div>
-      </div>
-      <div className="space-y-2">
-        {NOTES.map((n, i) => (
-          <div key={i} className="flex items-center justify-between" style={{ fontSize: "12.5px" }}>
-            <div className="truncate">{n.title}</div>
-            <div className="font-mono text-muted" style={{ fontSize: "10.5px" }}>{n.ago}</div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return <EmptyState icon="file-text" message="Connect Obsidian to see notes" delay="160ms" />;
 }
 
 export function DevQuicklaunch() {
@@ -224,17 +246,5 @@ export function WorkShortcuts() {
 }
 
 export function RedHatNews() {
-  return (
-    <div className="module p-4 module-enter" style={{ animationDelay: "280ms" }}>
-      <div className="flex items-center gap-2 mb-2.5">
-        <span className="rounded-full" style={{ width: 8, height: 8, background: "var(--rh)" }} />
-        <div className="font-mono uppercase" style={{ fontSize: "10.5px", letterSpacing: "0.16em" }}>Red Hat · internal</div>
-      </div>
-      <ul className="space-y-1.5" style={{ fontSize: "12.5px" }}>
-        {RED_HAT_NEWS.map((item, i) => (
-          <li key={i}>{item}</li>
-        ))}
-      </ul>
-    </div>
-  );
+  return <EmptyState icon="newspaper" message="No internal news configured" delay="280ms" />;
 }

--- a/src/components/scenes/Icons.tsx
+++ b/src/components/scenes/Icons.tsx
@@ -108,6 +108,16 @@ export function Icon({ name, size = 16, stroke = 1.6, className = '' }: IconProp
       return <svg {...common}><path d="M14 5h5v5M19 5l-9 9M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5" /></svg>;
     case 'chevron':
       return <svg {...common}><path d="m9 6 6 6-6 6" /></svg>;
+    case 'briefcase':
+      return <svg {...common}><rect x="2" y="7" width="20" height="14" rx="2" /><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2" /></svg>;
+    case 'file-text':
+      return <svg {...common}><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" /><path d="M14 3v6h6M9 13h6M9 17h4" /></svg>;
+    case 'newspaper':
+      return <svg {...common}><path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-2 2zm0 0a2 2 0 0 1-2-2v-9h4" /><path d="M10 6h8M10 10h4M10 14h8M10 18h4" /></svg>;
+    case 'shopping-cart':
+      return <svg {...common}><circle cx="9" cy="21" r="1" /><circle cx="20" cy="21" r="1" /><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" /></svg>;
+    case 'utensils':
+      return <svg {...common}><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2M7 2v20M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3zm0 0v7" /></svg>;
     default:
       return <svg {...common}><circle cx="12" cy="12" r="3" /></svg>;
   }

--- a/src/components/scenes/Scenes.tsx
+++ b/src/components/scenes/Scenes.tsx
@@ -88,12 +88,7 @@ export function SceneWeekdayPM({ teamNight, userName }: { teamNight: string | nu
       <Greeting scene="wkdy_pm" name={userName} />
       <div className="mt-8 grid grid-cols-12 gap-5">
         <div className="col-span-7"><TonightHero size="large" /></div>
-        <div className="col-span-5"><YouTubeFrame sub="Watch while cooking" video={{
-          title: "Kenji — Why a hard sear changes everything (12 min)",
-          channel: "J. Kenji López-Alt", ch_handle: "@JKenjiLopezAlt",
-          durTotal: "12:04", durElapsed: "3:18", viewers: "1.2M views",
-          thumb: "linear-gradient(135deg, #4a2a18 0%, #1a0904 50%, #b35c2a 100%)",
-        }} /></div>
+        <div className="col-span-5"><YouTubeFrame /></div>
       </div>
       <div className="mt-5 grid grid-cols-12 gap-5">
         <div className="col-span-5 space-y-5">
@@ -101,12 +96,12 @@ export function SceneWeekdayPM({ teamNight, userName }: { teamNight: string | nu
           <FantasyModule />
         </div>
         <div className="col-span-4 space-y-5">
-          <StreamingShelf scene="wkdy_pm" />
+          <StreamingShelf />
           <NowPlaying />
         </div>
         <div className="col-span-3 space-y-5">
           <GroceriesModule />
-          <YouTubeQueue scene="wkdy_pm" />
+          <YouTubeQueue />
         </div>
       </div>
       <div className="mt-5 grid grid-cols-12 gap-5">
@@ -166,29 +161,19 @@ export function SceneWeekendPM({ teamNight, userName }: { teamNight: string | nu
       <div className="mt-8 grid grid-cols-12 gap-5">
         <div className="col-span-7"><TonightHero size="large" /></div>
         <div className="col-span-5 space-y-5">
-          <YouTubeFrame sub="On the TV" video={{
-            title: teamNight === "chelsea" ? "Stamford Bridge — Chelsea v Man City · matchday vlog" :
-              teamNight === "camden" ? "Camden Yards — Henderson, in real time"
-              : "NFL RedZone · Sunday cuts you missed",
-            channel: teamNight === "chelsea" ? "Chelsea FC" : teamNight === "camden" ? "Jomboy Media" : "NFL",
-            ch_handle: teamNight === "chelsea" ? "@ChelseaFC" : teamNight === "camden" ? "@JomboyMedia" : "@NFL",
-            durTotal: "24:11", durElapsed: "6:42", viewers: "841K views",
-            thumb: teamNight === "chelsea" ? "linear-gradient(135deg,#0a2a66,#02153b 60%,#5fa9e3)" :
-              teamNight === "camden" ? "linear-gradient(135deg,#3a1808,#0e0402 60%,#df4601)"
-              : "linear-gradient(135deg,#1a3a2a,#06120a 60%,#4a8a5a)",
-          }} />
+          <YouTubeFrame />
           <ScoreRecap />
         </div>
       </div>
       <div className="mt-5 grid grid-cols-12 gap-5">
-        <div className="col-span-7"><StreamingShelf scene="wknd_pm" /></div>
+        <div className="col-span-7"><StreamingShelf /></div>
         <div className="col-span-5 space-y-5">
           <TeamDeepDive team={featured} />
         </div>
       </div>
       <div className="mt-5 grid grid-cols-12 gap-5">
         <div className="col-span-4"><SportsBoard slate="weekend_evening" title="primetime · late" subtitle="Wolves-Nuggets G4. UFC 322. Masters R4 prep." /></div>
-        <div className="col-span-4"><YouTubeQueue scene="wknd_pm" /></div>
+        <div className="col-span-4"><YouTubeQueue /></div>
         <div className="col-span-4 space-y-5">
           <FantasyModule />
           <NowPlaying />

--- a/src/lib/gmail-api.ts
+++ b/src/lib/gmail-api.ts
@@ -1,0 +1,75 @@
+export interface GmailMessage {
+  id: string;
+  from: string;
+  subject: string;
+  date: string;
+  snippet: string;
+}
+
+export interface GmailInbox {
+  unread: number;
+  starred: number;
+  messages: GmailMessage[];
+}
+
+const CACHE_KEY = "homepage_gmail";
+const CACHE_TTL = 5 * 60 * 1000;
+
+export async function fetchInbox(): Promise<GmailInbox> {
+  try {
+    const cached = localStorage.getItem(CACHE_KEY);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      if (Date.now() - parsed.timestamp < CACHE_TTL) return parsed.data;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  const res = await fetch("/api/gmail");
+  if (!res.ok) throw new Error("Gmail fetch failed");
+  const data: GmailInbox = await res.json();
+
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ data, timestamp: Date.now() }),
+    );
+  } catch {
+    /* quota */
+  }
+
+  return data;
+}
+
+export function formatEmailDate(dateStr: string): string {
+  try {
+    const d = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+    if (diffMin < 1) return "now";
+    if (diffMin < 60) return diffMin + "m";
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) return diffHr + "h";
+    const diffDays = Math.floor(diffHr / 24);
+    if (diffDays < 7) return diffDays + "d";
+    const h = d.getHours();
+    const m = d.getMinutes();
+    const ampm = h >= 12 ? "PM" : "AM";
+    const hour = h % 12 || 12;
+    return (
+      (d.getMonth() + 1) +
+      "/" +
+      d.getDate() +
+      " " +
+      hour +
+      ":" +
+      String(m).padStart(2, "0") +
+      " " +
+      ampm
+    );
+  } catch {
+    return "";
+  }
+}


### PR DESCRIPTION
Closes #60

## Changes
- **Gmail integration**: Added `gmail.readonly` OAuth scope, created `/api/gmail` serverless endpoint (session auth, CORS restricted), client hook with 5-min localStorage cache, and wired InboxModule to show real unread/starred counts and top 5 messages with Gmail web links
- **Calendar refinement**: WorkCalendar now filters for Red Hat calendar events only, PersonalCalendar filters for non-work events. Both show join links when available. Empty state when no events found
- **Empty states**: Created reusable `EmptyState` component with glassmorphism module card styling. Replaced placeholder content in 11 modules: ProjectsModule, NotesModule, RedHatNews, TonightHero, GroceriesModule, WeekendMealPlan, StreamingShelf, NowPlaying, YouTubeFrame, YouTubeQueue, FantasyModule
- **Icons**: Added briefcase, file-text, newspaper, shopping-cart, utensils icons
- MeetingTimeline, QuoteModule, sports live scores, markets, and news modules kept working as before

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (6/6)
- [ ] Verify Gmail shows real inbox when authenticated
- [ ] Verify calendar filters work vs personal events correctly
- [ ] Verify empty states render for all unconnected modules
- [ ] Verify no regressions in sports, weather, news, markets modules